### PR TITLE
Update qs_ubuntu_kvm.rst

### DIFF
--- a/source/design_and_installation/quick_starts/qs_ubuntu_kvm.rst
+++ b/source/design_and_installation/quick_starts/qs_ubuntu_kvm.rst
@@ -206,6 +206,12 @@ The ``oneadmin`` user must be able to manage libvirt as root:
     group = "oneadmin"
     dynamic_ownership = 0
     EOT
+    
+Restart libvirt to capture these changes:
+
+.. code::
+
+    # service libvirt-bin restart
 
 Step 3. Basic Usage
 ===================


### PR DESCRIPTION
After following instructions in this guide, had issues with nodes having insufficient permissions to create new instances. Restarting libvirt on the node resolved the problem, but this step is not mentioned explicitly in the guide. Added a line in step 2.5 reflecting this.
