### PR TITLE
Update openvswitch.rst

### DIFF
--- a/source/administration/networking/openvswitch.rst
+++ b/source/administration/networking/openvswitch.rst
@@ -164,6 +164,15 @@ These rules prevent any traffic to come out of the port the MAC address has chan
 
     in_port=<PORT>,dl_src=<MAC>,priority=40000,actions=normal
     in_port=<PORT>,priority=39000,actions=normal
+    
+**IP hijacking**
+
+These rules prevent any traffic to come out of the port for IPv4 IP's not configured for a VM
+
+.. code::
+
+    in_port=<PORT>,arp,dl_src=<MAC>priority=45000,actions=drop
+    in_port=<PORT>,arp,dl_src=<MAC>,nw_src=<IP>,priority=46000,actions=normal
 
 **Black ports (one rule per port)**
 


### PR DESCRIPTION
Today I found out that not only "mac-spoofing" prevention filters are active, but also "IP hijacking" filters for IPv4. This should be reflected in the docs, would have saved me some time. Ideally IPv6 hijacking should also be implemented, I might right a small patch for that later. IP-aliases should be possible however, so all ip-adresses that _are_ configured are allowed. IP Hijack prevention is a great feature, especially for public clouds.
