### PR TITLE
Updated rOCCI-server link in 4.8 release notes

### DIFF
--- a/source/release_notes/release_notes/compatibility.rst
+++ b/source/release_notes/release_notes/compatibility.rst
@@ -74,7 +74,7 @@ Developers and Integrators
 Public Clouds APIs
 --------------------------------------------------------------------------------
 
-The OCCI server is no longer part of the distribution and now resides in an `addon repository <https://github.com/OpenNebula/addon-occi>`_. If you are searching for an OCCI server you'd better use the `rOCCI Server <http://gwdg.github.io/rOCCI-server/>`_.
+The OCCI server is no longer part of the distribution and now resides in an `addon repository <https://github.com/OpenNebula/addon-occi>`_. If you are searching for an OCCI server you'd better use the `rOCCI-server <http://egi-fctf.github.io/rOCCI-server/>`_.
 
 Storage
 --------------------------------------------------------------------------------


### PR DESCRIPTION
Link should point to the official EGI FCTF repository.
