### PR TITLE
No opennebula-context in CentOS/RedHat repo

### DIFF
--- a/source/user/virtual_machine_setup/bcont.rst
+++ b/source/user/virtual_machine_setup/bcont.rst
@@ -18,7 +18,7 @@ The contextualization package will also mount any partition labeled ``swap`` as 
 -  Start a image (or finish its installation)
 -  Install context packages with one of these methods:
 
-   -  Install from our repositories package **one-context** in Ubuntu/Debian or **opennebula-context** in CentOS/RedHat. Instructions to add the repository at the :ref:`installation guide <ignc>`.
+   -  Install from our repositories package **one-context** in Ubuntu/Debian. Instructions to add the repository at the :ref:`installation guide <ignc>`.
    -  Download and install the package for your distribution:
 
       -  `DEB <http://dev.opennebula.org/attachments/download/806/one-context_4.8.0.deb>`__: Compatible with Ubuntu 11.10 to 14.04 and Debian 6/7


### PR DESCRIPTION
Couldn't find opennebula-context:

```
[root@nebula ~]# cat /etc/yum.repos.d/opennebula.repo    
[opennebula]
name=opennebula
baseurl=http://downloads.opennebula.org/repo/4.8/CentOS/6/x86_64
enabled=1
gpgcheck=0
[root@nebula ~]# yum search opennebula-context        
Loaded plugins: fastestmirror
Loading mirror speeds from cached hostfile
 * base: ftp.plusline.de
 * epel: mirror.23media.de
 * extras: ftp.hosteurope.de
 * updates: mirror.23media.de
Warning: No matches found for: opennebula-context
No Matches found
```
