### PR TITLE
Fix minor typo (diver vs. driver)

### DIFF
--- a/source/integration/infrastructure_integration/devel-im.rst
+++ b/source/integration/infrastructure_integration/devel-im.rst
@@ -21,7 +21,7 @@ In the case of ``KVM`` and ``Xen``, the probes are distributed to the hosts, the
 General Probe Structure
 =======================
 
-An IM diver is composed of one or several scripts that write to ``stdout`` information in this form:
+An IM driver is composed of one or several scripts that write to ``stdout`` information in this form:
 
 .. code::
 

--- a/source/locale/es/LC_MESSAGES/integration/infrastructure_integration/devel-im.po
+++ b/source/locale/es/LC_MESSAGES/integration/infrastructure_integration/devel-im.po
@@ -59,7 +59,7 @@ msgstr ""
 
 #: ../../source/integration/infrastructure_integration/devel-im.rst:24
 msgid ""
-"An IM diver is composed of one or several scripts that write to ``stdout`` "
+"An IM driver is composed of one or several scripts that write to ``stdout`` "
 "information in this form:"
 msgstr ""
 


### PR DESCRIPTION
Hi, 

while reading through http://docs.opennebula.org/4.12/integration/infrastructure_integration/devel-im.html i noticed a small typo "diver" vs "driver". This pull-request fixes that.

Best wishes,
Matthias
 