### PR TITLE
example ds.conf does not have CEPH_HOST entry, which is required

### DIFF
--- a/source/administration/storage/ceph_ds.rst
+++ b/source/administration/storage/ceph_ds.rst
@@ -107,6 +107,7 @@ An example of datastore:
     NAME = "cephds"
     DS_MAD = ceph
     TM_MAD = ceph
+    CEPH_HOST = host1 host2:port2 
 
     # the following lines *must* be preset
     DISK_TYPE = RBD


### PR DESCRIPTION
CEPH_HOST should be part of the example file, I believe it is required. 