### PR TITLE
Update sm.rst

### DIFF
--- a/source/administration/storage/sm.rst
+++ b/source/administration/storage/sm.rst
@@ -90,7 +90,7 @@ The following stable reflects the compatiblity of disk snapshotting and disk liv
 +===================+========+=====+=======+======+======+=====+========+=====+
 | Snapshotting      | x      | x   | x     |      | x    |     |        |     |
 +-------------------+--------+-----+-------+------+------+-----+--------+-----+
-| Live Snapshotting |        |     | x     |      |      |     |        |     |
+| Live Snapshotting |        |     | x     |      | x    |     |        |     |
 +-------------------+--------+-----+-------+------+------+-----+--------+-----+
 
 Datastore Attributes


### PR DESCRIPTION
Ceph live-snapshotting was fixed in 4.14.2, right? 

grep LIVE /etc/one/vmm_exec/vmm_execrc 
LIVE_DISK_SNAPSHOTS="kvm-qcow2 kvm-ceph"