### PR TITLE
Update build_deps.rst

### DIFF
--- a/source/integration/references/build_deps.rst
+++ b/source/integration/references/build_deps.rst
@@ -31,6 +31,9 @@ Debian/Ubuntu
 -  **liblog4cpp5-dev**
 -  **ruby**
 
+Note: With Ubuntu 14.04, libxmlrpc-c3-dev no longer exists. Instead, install these packages
+libxmlrpc-c++8-dev, libxmlrpc-core-c3-dev.
+
 CentOS 6
 ========
 


### PR DESCRIPTION
With Ubuntu 14.04, libxmlrpc-c3-dev no longer exists. Instead, we'd need to install l these packages:
libxmlrpc-c++8-dev, libxmlrpc-core-c3-dev.