### PR TITLE
Fix inconsistency between XMLRPC operation and docs

### DIFF
--- a/source/integration/system_interfaces/api.rst
+++ b/source/integration/system_interfaces/api.rst
@@ -1011,8 +1011,8 @@ one.vm.migrate
 | OUT  | Int        | Error code.                                                            |
 +------+------------+------------------------------------------------------------------------+
 
-one.vm.disksave
----------------
+one.vm.disksaveas
+-----------------
 
 -  **Description**: Sets the disk to be saved in the given image.
 -  **Parameters**


### PR DESCRIPTION
Docs stated the operation 'one.vm.disksave' existed. The real name is 'one.vm.disksaveas'