### PR TITLE
edit systemd opennebula.service file on ubuntu

### DIFF
--- a/source/deployment/opennebula_installation/mysql_setup.rst
+++ b/source/deployment/opennebula_installation/mysql_setup.rst
@@ -66,6 +66,23 @@ Fields:
 * **passwd**: MySQL password.
 * **db_name**: Name of the MySQL database OpenNebula will use.
 
+
+Editing Systemd opennebula.service script
+-----------------------------------------
+
+When on Ubuntu 16.04 and using OpenNebula with MySQL you might notice OpenNebula backend service not starting up automatically on system boot due to MySQL not having been started yet. In this case you may wish to edit /lib/systemd/system/opennebula.service and replace
+
+.. code::
+
+    After=mariadb.service
+    
+with
+
+.. code::
+
+    After=mysql.service
+
+
 Using OpenNebula with MySQL
 ===========================
 


### PR DESCRIPTION
There is no mariadb.service on my Ubuntu 16.04. Instead I have mysql.service. So when using opennebula with MySQL I want MySQL to be started and running before opennebula.service is being started. There is After=mariadb.service in opennebula.service but I need After=mysql.service instead.