### PR TITLE
Delete cloud-init before installing one-context

### DIFF
--- a/source/operation/vm_setup/add_content.rst
+++ b/source/operation/vm_setup/add_content.rst
@@ -114,13 +114,13 @@ CentOS 6
     mkdir /tmp/mount
     mount LABEL=PACKAGES /tmp/mount
 
+    # Remove cloud-init and NetworkManager
+    yum remove -y NetworkManager cloud-init
+
     yum install -y epel-release --nogpgcheck
 
     # Install opennebula context package
     yum localinstall -y /tmp/mount/one-context*el6*rpm
-
-    # Remove cloud-init and NetworkManager
-    yum remove -y NetworkManager cloud-init
 
     # Install growpart and upgrade util-linux
     yum install -y cloud-utils-growpart --nogpgcheck
@@ -140,13 +140,13 @@ CentOS 7
     mkdir /tmp/mount
     mount LABEL=PACKAGES /tmp/mount
 
+    # Remove cloud-init and NetworkManager
+    yum remove -y NetworkManager cloud-init
+
     yum install -y epel-release --nogpgcheck
 
     # Install opennebula context package
     yum localinstall -y /tmp/mount/one-context*el7*rpm
-
-    # Remove cloud-init and NetworkManager
-    yum remove -y NetworkManager cloud-init
 
     # Install growpart and upgrade util-linux
     yum install -y cloud-utils-growpart --nogpgcheck


### PR DESCRIPTION
New 5.3.80 one-context "provides" cloud-init (not a big fan, but whatever...)
So installing new 5.3.80 one-context with previous instructions sort-of updates cloud-init package, which is then removed, removing one-context.
It's safe for old and new one-context package to first remove cloud-init and then install one-context

(i have no clue if this is relevant for other OSes)