### PR TITLE
update sphinx theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ You are encouraged to fork this repo and send us pull requests!
 Building
 --------
 
-Install dependencies: ``pip install sphinx sphinx_bootstrap_theme``.
+Install dependencies: ``pip install sphinx sphinx_rtd_theme``.
 
 Build the documentation by running ``make html``.
 [More information](http://sphinx-doc.org/).


### PR DESCRIPTION
I think that the ONE doc project use the sphinx_rtd_theme and not the sphinx_bootstrap_theme

