### PR TITLE
Change service command to systemctl.

### DIFF
--- a/source/deployment/node_installation/kvm_node_installation.rst
+++ b/source/deployment/node_installation/kvm_node_installation.rst
@@ -24,7 +24,7 @@ Execute the following commands to install the node package and restart libvirt t
 .. prompt:: bash $ auto
 
     $ sudo yum install opennebula-node-kvm
-    $ sudo service libvirtd restart
+    $ sudo systemctl restart libvirtd
 
 For further configuration, check the specific guide: :ref:`KVM <kvmg>`.
 


### PR DESCRIPTION
This updates the command to restart libvirtd from `service` to `systemctl`. While invoking `service` will still work, it is depreciated.