### PR TITLE
Apt-get updated needed after adding repositories

### DIFF
--- a/source/deployment/node_installation/kvm_node_installation.rst
+++ b/source/deployment/node_installation/kvm_node_installation.rst
@@ -46,6 +46,7 @@ Execute the following commands to install the node package and restart libvirt t
 
 .. prompt:: bash $ auto
 
+    $ sudo apt-get update
     $ sudo apt-get install opennebula-node
     $ sudo service libvirtd restart # debian
     $ sudo service libvirt-bin restart # ubuntu


### PR DESCRIPTION
When you follow the docs step-by-step, and do not run apt-get update after adding the repositories, you risk installing the OS-variant of opennebula-node, and not the one from the repository that was just added.