### PR TITLE
B #2420: removed line about vCenter image requirements

### DIFF
--- a/source/deployment/vmware_infrastructure_setup/datastore_setup.rst
+++ b/source/deployment/vmware_infrastructure_setup/datastore_setup.rst
@@ -42,7 +42,6 @@ Limitations
 
 * When a vCenter template or wild VM is imported into OpenNebula, the virtual disks are imported, an images are created in OpenNebula representing those virtual disks. Although these images represent files that already exist in the datastores, OpenNebula accounts the size of those imported images as if they were new created files and therefore the datastore capacity is decreased even though no real space in the vCenter datastore is being used by the OpenNebula images. You should understand this limitation if for example an image cannot be imported as OpenNebula reports that no more space is left or if you're using disk quotas.
 * No support for disk snapshots in the vCenter datastore.
-* Image names and paths cannot contain spaces or non ASCII characters.
 
 
 The vCenter Transfer Manager


### PR DESCRIPTION
Related to [this issue](https://github.com/OpenNebula/one/issues/2437).

We aim for relase 5.6.2 and we still have to perform some testing actions so we need to wait for 5.6.1 and the proper merge of this [PR](https://github.com/OpenNebula/one/pull/2425).

Also we should add this to the next resolved issues for 5.6.2