### PR TITLE
Pass scheme to support Secure cookies in sunstone

### DIFF
--- a/source/deployment/sunstone_setup/suns_auth.rst
+++ b/source/deployment/sunstone_setup/suns_auth.rst
@@ -256,7 +256,10 @@ You will need to configure a new virtual host in nginx. Depending on the operati
 
             ### Proxy requests to upstream
             location / {
-                     proxy_pass http://sunstone;
+                    proxy_pass              http://sunstone;
+                    proxy_set_header        X-Real-IP $remote_addr;
+                    proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
+                    proxy_set_header        X-Forwarded-Proto $scheme;
             }
     }
 


### PR DESCRIPTION
Recommend the user to pass Forwarded-For and Forwarded-Proto scheme to let Sinatra know what the URL scheme requested is. 

The URL scheme is useful so Sunstone can potentially set cookies with a Secure flag.

It's also potentially useful (in the future?) to let Sinatra know what the real request address is, so I've included that.

