### PR TITLE
M #-: Remove LaTeX incompatible codes

### DIFF
--- a/source/deployment/open_cloud_host_setup/kvm_driver.rst
+++ b/source/deployment/open_cloud_host_setup/kvm_driver.rst
@@ -158,7 +158,7 @@ OpenNebula automatically generates a number of CPU shares proportional to the CP
     ...
     |-- cpu.shares
     |-- cpu.stat
-    |-- machine-qemu\x2d1\x2done\x2d73.scope
+    |-- machine-qemu-1-one-73.scope
     |   |-- cgroup.clone_children
     |   |-- cgroup.event_control
     |   |-- cgroup.procs
@@ -167,7 +167,7 @@ OpenNebula automatically generates a number of CPU shares proportional to the CP
     |   `-- vcpu0
     |       |-- cgroup.clone_children
     |       ...
-    |-- machine-qemu\x2d2\x2done\x2d74.scope
+    |-- machine-qemu-2-one-74.scope
     |   |-- cgroup.clone_children
     |   |-- cgroup.event_control
     |   |-- cgroup.procs
@@ -183,9 +183,9 @@ with the CPU shares for each VM:
 
 .. prompt:: bash $ auto
 
-    $ cat '/sys/fs/cgroup/cpu,cpuacct/machine.slice/machine-qemu\x2d1\x2done\x2d73.scope/cpu.shares'
+    $ cat '/sys/fs/cgroup/cpu,cpuacct/machine.slice/machine-qemu-1-one-73.scope/cpu.shares'
     512
-    $ cat '/sys/fs/cgroup/cpu,cpuacct/machine.slice/machine-qemu\x2d2\x2done\x2d74.scope/cpu.shares'
+    $ cat '/sys/fs/cgroup/cpu,cpuacct/machine.slice/machine-qemu-2-one-74.scope/cpu.shares'
     1024
 
 .. note:: The cgroups (directory) layout can be different based on your operating system and configuration. The `libvirt documentation <https://libvirt.org/cgroups.html>`__ describes all the cases and a way the cgroups are managed by libvirt/KVM.

--- a/source/deployment/sunstone_setup/sunstone.rst
+++ b/source/deployment/sunstone_setup/sunstone.rst
@@ -424,7 +424,7 @@ its console dialog that communicates with the proxy by using websockets.
 .. note:: For the correct functioning of the SPICE Web Client, we recommend defining by default
     some SPICE parameters in ``/etc/one/vmm_mad/vmm_exec_kvm.conf``. In this way, once modified the
     file and restarted OpenNebula, it will be applied to all the VMs instantiated from now on. You can
-    also override these SPICE parameters ​​in VM Template. For more info check :ref:`Driver Defaults
+    also override these SPICE parameters in VM Template. For more info check :ref:`Driver Defaults
     <kvmg_default_attributes>` section.
 
 .. _virt_viewer_sunstone:

--- a/source/operation/vm_management/vm_instances.rst
+++ b/source/operation/vm_management/vm_instances.rst
@@ -978,7 +978,7 @@ The command can also be set for each container, by updating the ``GRAPHICS`` sec
 
 .. note:: For the correct functioning of the SPICE Web Client, we recommend defining by default some SPICE parameters in ``/etc/one/vmm_mad/vmm_exec_kvm.conf``.
   In this way, once modified the file and restarted OpenNebula, it will be applied to all the VMs instantiated from now on.
-  You can also override these SPICE parameters ​​in VM Template. For more info check :ref:`Driver Defaults <kvmg_default_attributes>` section.
+  You can also override these SPICE parameters in VM Template. For more info check :ref:`Driver Defaults <kvmg_default_attributes>` section.
 
 .. warning:: It is advised for RPM distros to update the command since it doesn't work when running it through ``lxc exec``. For example, a valid command would be ``/bin/bash``. Keep in mind it grants a root shell inside the container.
 


### PR DESCRIPTION
It is impossible to generate PDF documentation with LaTeX, because some codes (few looks like unicode and few are suspicious) causes LaTeX to bail-out with errors like:

```
! Package inputenc Error: Unicode character ​ (U+200B)
(inputenc)                not set up for use with LaTeX.

See the inputenc package documentation for explanation.
Type  H <return>  for immediate help.
 ...

l.8695 ...also override these SPICE parameters ​
```

This PR removes these codes which fixes PDF generation in my environment.

How to reproduce - tested on Debian10:

```shell
sudo apt-get install git make python3-sphinx-rtd-theme \
     python3-yaml python3-dev python3-pip 
sudo pip3 install sphinx-prompt
mkdir ~/projects
cd ~/projects
git clone https://github.com/OpenNebula/docs.git
cd docs/
# I used exactly this version of Docs:
git describe --long --always --dirty
# 8916f2ce
# HTML version shuld proceed fine:
make html

# now prepare LaTeX for PDF
sudo apt-get install latexmk texlive-latex-recommended \
  texlive-fonts-recommended texlive-latex-extra

# this command will fail with above error
make latexpdf
```

> WARNING!
>
> GitHub Web UI is unable to show properly difference on these non-ASCII sequences in PR.
> Please use local `git diff` to see these changes.


Sidenote: When I look into PDF repository at:
- http://docs.opennebula.io/pdf/
It seems that last PDF manuals are for version `5.10` which is behind current `5.12` release. Are there any other issues
with PDF generation?

