### PR TITLE
B #5437: PyONE strips white-spaces in VM attribute

### DIFF
--- a/source/intro_release_notes/release_notes_community/resolved_issues_6003.rst
+++ b/source/intro_release_notes/release_notes_community/resolved_issues_6003.rst
@@ -14,4 +14,4 @@ The following new features has been backported to 6.0.0.3:
 The following issues has been solved in 6.0.0.3:
 
 - `Provide nice and clear! description <https://github.com/OpenNebula/one/issues/XXX>`__.
-- `Fix PyONE strips white-spaces of VM attributes <https://github.com/OpenNebula/one/issues/5437>`__.
+

--- a/source/intro_release_notes/release_notes_community/resolved_issues_6003.rst
+++ b/source/intro_release_notes/release_notes_community/resolved_issues_6003.rst
@@ -14,3 +14,4 @@ The following new features has been backported to 6.0.0.3:
 The following issues has been solved in 6.0.0.3:
 
 - `Provide nice and clear! description <https://github.com/OpenNebula/one/issues/XXX>`__.
+- `Fix PyONE strips white-spaces of VM attributes <https://github.com/OpenNebula/one/issues/5437>`__.

--- a/source/intro_release_notes/release_notes_community/resolved_issues_6003.rst
+++ b/source/intro_release_notes/release_notes_community/resolved_issues_6003.rst
@@ -14,4 +14,3 @@ The following new features has been backported to 6.0.0.3:
 The following issues has been solved in 6.0.0.3:
 
 - `Provide nice and clear! description <https://github.com/OpenNebula/one/issues/XXX>`__.
-

--- a/source/intro_release_notes/release_notes_enterprise/resolved_issues_603.rst
+++ b/source/intro_release_notes/release_notes_enterprise/resolved_issues_603.rst
@@ -43,3 +43,4 @@ The following issues has been solved in 6.0.3:
 - `Fix create image on Sunstone vcenter mode <https://github.com/OpenNebula/one/issues/5432>`__.
 - `Fix schedule actions days translation <https://github.com/OpenNebula/one/issues/5436>`__.
 - `Disable Sunstone autorefresh due to a security concern <https://github.com/OpenNebula/one/issues/5427>`__.
+- `Fix PyONE strips white-spaces of VM attributes <https://github.com/OpenNebula/one/issues/5437>`__.


### PR DESCRIPTION
Signed-off-by: Ricardo Diaz <rdiaz@opennebula.io>