### PR TITLE
B OpenNebula/one#2187: Fix IPv6 size not required with no-SLAAC

### DIFF
--- a/source/intro_release_notes/release_notes_enterprise/resolved_issues_603.rst
+++ b/source/intro_release_notes/release_notes_enterprise/resolved_issues_603.rst
@@ -44,3 +44,4 @@ The following issues has been solved in 6.0.3:
 - `Fix schedule actions days translation <https://github.com/OpenNebula/one/issues/5436>`__.
 - `Disable Sunstone autorefresh due to a security concern <https://github.com/OpenNebula/one/issues/5427>`__.
 - `Fix OpenNebula version shown on Sunstone <https://github.com/OpenNebula/one/issues/5428>`__.
+- `Fix IPv6 networks should not ask for size when no-SLAAC <https://github.com/OpenNebula/one/issues/2187>`__.


### PR DESCRIPTION
This PR applies to:
- one-6.0-maintenance

Signed-off-by: Frederick Borges <fborges@opennebula.io>