### PR TITLE
B OpenNebula/one#5651: Fix VMTemplate lock and unlock

### DIFF
--- a/source/intro_release_notes/release_notes_enterprise/resolved_issues_621.rst
+++ b/source/intro_release_notes/release_notes_enterprise/resolved_issues_621.rst
@@ -26,3 +26,4 @@ The following issues has been solved in 6.2.1:
 - `Fix LXD qcow2 mapper failing with extra disks <https://github.com/OpenNebula/one-ee/pull/1613>`__.
 - `Fix missing STDERR on LXD nic tap parsing <https://github.com/OpenNebula/one/issues/5652>`__.
 - `Fix VMs monitored as POWEROFF instead of UNKNOWN just before a crash <https://github.com/OpenNebula/one/issues/5564>`__.
+- `Fix VMTemplate lock and unlock <https://github.com/OpenNebula/one/issues/5651>`__.


### PR DESCRIPTION
This PR applies to:
- one-6.2-maintenance

Signed-off-by: Frederick Borges <fborges@opennebula.io>