### PR TITLE
B OpenNebula/one#5650: Hide SSH configurations on settings.ssh_key false

### DIFF
--- a/source/intro_release_notes/release_notes_enterprise/resolved_issues_51211.rst
+++ b/source/intro_release_notes/release_notes_enterprise/resolved_issues_51211.rst
@@ -26,3 +26,4 @@ The following issues has been solved in 5.12.11:
 - `Fix Sunstone misbehave with service user inputs <https://github.com/OpenNebula/one/issues/5578>`__.
 - `Fix missing STDERR on LXD nic tap parsing <https://github.com/OpenNebula/one/issues/5652>`__.
 - `Fix VMs monitored as POWEROFF instead of UNKNOWN just before a crash <https://github.com/OpenNebula/one/issues/5564>`__.
+- `Fix hide SSH configuration when hiden by yaml <https://github.com/OpenNebula/one/issues/5650>`__.


### PR DESCRIPTION
This PR applies to:
- one-5.12-maintenance

Signed-off-by: Frederick Borges <fborges@opennebula.io>