### PR TITLE
Fixing typo in overview page.

### DIFF
--- a/source/quick_start/usage_basics/overview.rst
+++ b/source/quick_start/usage_basics/overview.rst
@@ -6,6 +6,6 @@ Overview
 
 You made it all the way here, congratulations!
 
-Now it's time to launch some nice services to be hosted by your new OpenNebula cloud. If you followed the Operations Basics guide you most likely now have an LXC virtual Edge Cluster, so you are good to try out :ref:`running containers <running_containers>`.
+Now it's time to launch some nice services to be hosted by your new OpenNebula cloud. If you followed the Operations Basics guide, you most likely now have an LXC virtual Edge Cluster, so you are good to try out :ref:`running containers <running_containers>`.
 
-If you also deploy a KVM metal Edge Cluster (caution, this is pricier) you can also follow the :ref:`running virutal machines <running_virtual_machines>` and :ref:`running Kubernetes clusters <running_containers>` guides.
+If you also deploy a KVM metal Edge Cluster (caution, this is pricier) you can also follow the :ref:`running virtual machines <running_virtual_machines>` and :ref:`running Kubernetes clusters <running_containers>` guides.


### PR DESCRIPTION
Just a tiny typo in the page: `virutal` instead of `virtual`.
And as an added bonus, I added a comma for a better punctuation :smile: .