### PR TITLE
B #5370: fix names with | char cannot be imported from vCenter

### DIFF
--- a/source/intro_release_notes/release_notes_enterprise/resolved_issues_621.rst
+++ b/source/intro_release_notes/release_notes_enterprise/resolved_issues_621.rst
@@ -32,3 +32,4 @@ The following issues has been solved in 6.2.1:
 - `Fix vCenter 6 and 7 back-compatibility issue <https://github.com/OpenNebula/one/issues/5662>`__.
 - `Fix Sunstone tooltips <https://github.com/OpenNebula/one/issues/5534>`__.
 - `Disable sensitive information in guacamole <https://github.com/OpenNebula/one/issues/5672>`__.
+- `Fix names with "|" char cannot be imported from vCenter <https://github.com/OpenNebula/one/issues/5370>`__.


### PR DESCRIPTION
-> one-6.2-maintenance

Signed-off-by: Carlos Herrera <cherrera@opennebula.io>