### PR TITLE
B OpenNeubla/one#5701: Show external IPs on VM datatable

### DIFF
--- a/source/intro_release_notes/release_notes_enterprise/resolved_issues_621.rst
+++ b/source/intro_release_notes/release_notes_enterprise/resolved_issues_621.rst
@@ -45,3 +45,4 @@ The following issues has been solved in 6.2.1:
 - `Fix race condition between iptables and ipsets when cleaning VM network <https://github.com/OpenNebula/one/commit/1bd9a83659edd518476a2ad34f0bdc7c3caffc9e>`__.
 - `Fix FT VM migration for the fs_lvm_ssh driver <https://github.com/OpenNebula/one/issues/5699>`__.
 - `Fix Image templates after a disk save_as operation by removing SAVE_AS_HOT attribute <https://github.com/OpenNebula/one/issues/5699>`__.
+- `Fix IPs from GUEST_IP_ADDRESSES attribute were not showing in VMs datatable <https://github.com/OpenNebula/one/issues/5701>`__.


### PR DESCRIPTION
This PR applies to:
- one-6.2-maintenance

Signed-off-by: Frederick Borges <fborges@opennebula.io>