### PR TITLE
B OpenNeubla/one#5701: Show external IPs on VM datatable

### DIFF
--- a/source/intro_release_notes/release_notes_enterprise/resolved_issues_51212.rst
+++ b/source/intro_release_notes/release_notes_enterprise/resolved_issues_51212.rst
@@ -7,4 +7,4 @@ A complete list of solved issues for 5.12.12 can be found in the `project develo
 
 The following issues has been solved in 5.12.12:
 
-- `XXXXX <https://github.com/OpenNebula/one/issues/XXX>`__.
+- `Fix IPs from GUEST_IP_ADDRESSES attribute were not showing in VMs datatable <https://github.com/OpenNebula/one/issues/5701>`__.


### PR DESCRIPTION
This PR applies to:
- one-5.12-maintenance

Signed-off-by: Frederick Borges <fborges@opennebula.io>