### PR TITLE
B OpenNebula/one#5707: Hide remote console options not available

### DIFF
--- a/source/intro_release_notes/release_notes_enterprise/resolved_issues_621.rst
+++ b/source/intro_release_notes/release_notes_enterprise/resolved_issues_621.rst
@@ -49,3 +49,4 @@ The following issues has been solved in 6.2.1:
 - `Fix Sunstone not showing disk cache and size when selecting LXC <https://github.com/OpenNebula/one/issues/5641>`__.
 - `Improve RESTfulness of FireEdge API <https://github.com/OpenNebula/one/issues/5703>`__.
 - `Fix Sunstone deletes attributes that were not changed when showback disabled <https://github.com/OpenNebula/one/issues/5696>`__.
+- `Fix Sunstone shouldn't show not available option for remote console access <https://github.com/OpenNebula/one/issues/5707>`__.


### PR DESCRIPTION
This PR applies to:
- one-6.2-maintenance

Signed-off-by: Frederick Borges <fborges@opennebula.io>