### PR TITLE
F OpenNebula/one#5429: feature documentation

### DIFF
--- a/source/intro_release_notes/release_notes/whats_new.rst
+++ b/source/intro_release_notes/release_notes/whats_new.rst
@@ -41,6 +41,7 @@ KVM
 
 LXC
 ===
+- `Mount options for Storage Interfaces <https://github.com/OpenNebula/one/issues/5429>`__.
 
 Other Issues Solved
 ================================================================================
@@ -50,4 +51,3 @@ Features Backported to 6.2.x
 ============================
 
 Additionally, a lot of new functionality is present that was not in OpenNebula 6.2.0, although they debuted in subsequent maintenance releases of the 6.2.x series:
-

--- a/source/open_cluster_deployment/lxc_node/lxc_driver.rst
+++ b/source/open_cluster_deployment/lxc_node/lxc_driver.rst
@@ -114,8 +114,22 @@ LXC driver-specific configuration is available in ``/var/lib/one/remotes/etc/vmm
 |                            | will be included in the configuration of every LXC                 |
 |                            | container                                                          |
 +----------------------------+--------------------------------------------------------------------+
-| ``:bindfs_mountopts``      | Comma separated list of mount options used when shifting the       |
-|                            | uid/gid with bindfs. See <bindfs -o> command help.                 |
+
+Mount options configuration section also in lxcrc
+
++----------------------------+--------------------------------------------------------------------+
+| ``:bindfs``                | Comma separated list of mount options used when shifting the       |
+|                            | uid/gid with bindfs. See <bindfs -o> command help                  |
++----------------------------+--------------------------------------------------------------------+
+| ``:dev_<fs>``              | Mount options for disk devices (in the host). Options are set per  |
+|                            | fs type (e.g. dev_xfs, dev_ext3...)                                |
++----------------------------+--------------------------------------------------------------------+
+| ``:disk``                  | Mount options for data DISK in the contianer (lxc.mount.entry)     |
++----------------------------+--------------------------------------------------------------------+
+| ``:rootfs``                | Mount options for root fs in the container (lxc.rootfs.options)    |
++----------------------------+--------------------------------------------------------------------+
+| ``:mountpoint``            | Default Path to mount data disk in the container. This can be      |
+|                            | set per DISK using the TARGET attribute                            |
 +----------------------------+--------------------------------------------------------------------+
 
 Storage


### PR DESCRIPTION
Closes OpenNebula/one#5429

Template reference was already specifying the usage of TARGET from migrating the LXD driver documentation.