### PR TITLE
Remove replace CentOS where appropriate

### DIFF
--- a/source/installation_and_configuration/frontend_installation/database.rst
+++ b/source/installation_and_configuration/frontend_installation/database.rst
@@ -54,7 +54,7 @@ Install
 
 First of all, you need a working MySQL or MariaDB server. You can either deploy one for the OpenNebula installation following the guides for your operating system or reuse an existing one accessible via the Front-end. We assume you have a working MySQL/MariaDB server installed.
 
-.. note:: MySQL should be recent enough to support the FULLTEXT indexing used by OpenNebula to implement the VM search feature. For MariaDB, that means at least a late minor version of release 10.0 if you use the default InnoDB.  If you are using CentOS 7 you may be interested in install packages from Software Collections (``centos-release-scl-rh``) and probably the ``syspaths`` variants (``rh-mariadb103-mariadb-config-syspaths``, ``rh-mariadb103-mariadb-syspaths``, and ``rh-mariadb103-mariadb-server-syspaths``) to provide the usual MySQL paths. On RHEL 7, subscribe to the ``rhel-server-rhscl-7-rpms`` repo and then install the ``rh-mariadb`` packages.
+.. note:: MySQL should be recent enough to support the FULLTEXT indexing used by OpenNebula to implement the VM search feature. For MariaDB, that means at least a late minor version of release 10.0 if you use the default InnoDB.
 
 Configure
 ---------
@@ -119,7 +119,7 @@ The **PostgreSQL** Back-end is an alternative to SQLite and MySQL/MariaDB Back-e
 
 Features:
 
-* Required **PostgreSQL 9.5 or newer** (WARNING: base RHEL/CentOS 7 contains unsupported PostgreSQL 9.2!)
+* Required **PostgreSQL 9.5 or newer** (WARNING: base RHEL 7 contains unsupported PostgreSQL 9.2!)
 * No migrator for existing deployments from SQLite or MySQL/MariaDB
 * No full-text search support
 

--- a/source/installation_and_configuration/frontend_installation/install.rst
+++ b/source/installation_and_configuration/frontend_installation/install.rst
@@ -17,7 +17,7 @@ This page describes how to install a complete OpenNebula Front-end from binary p
 
 Proceed with the following steps to get the fully-featured OpenNebula Front-end up.
 
-Step 1. Disable SELinux on CentOS/RHEL (Optional)
+Step 1. Disable SELinux on AlmaLinux/RHEL (Optional)
 ================================================================================
 
 Depending on the type of OpenNebula deployment, the SELinux can block some operations initiated by the OpenNebula Front-end, which results in a failure of the particular operation.  It's **not recommended to disable** the SELinux in production environments as it degrades the security of your server, but instead to investigate and work around each individual problem based on the `SELinux User's and Administrator's Guide <https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/selinux_users_and_administrators_guide/>`__. The administrator might disable the SELinux to temporarily work around the problem or on non-production deployments by changing the following line in ``/etc/selinux/config``:
@@ -41,14 +41,7 @@ Step 3. Add 3rd Party Repositories
 
 Not all OpenNebula dependencies are in base distribution repositories. On selected platforms below you need to enable 3rd party repositories by running the following commands under privileged user (``root``):
 
-**CentOS 7**
-
-.. prompt:: bash # auto
-
-    # yum -y install epel-release
-    # yum -y install centos-release-scl-rh
-
-**CentOS 8**
+**AlmaLinux 8 (6.2.1 EE only)**
 
 .. prompt:: bash # auto
 
@@ -112,7 +105,7 @@ Available packages for OpenNebula clients, the Front-end and hypervisor Nodes:
 +------------------------------------------+---------------------------------------------------------------------------------------------------------------+
 | **opennebula-node-firecracker**          | Base setup for Firecracker hypervisor Node                                                                    |
 +------------------------------------------+---------------------------------------------------------------------------------------------------------------+
-| **opennebula-node-lxc**                  | Base setup for LXC hypervisor Node (*not on CentOS/RHEL 7*)                                                   |
+| **opennebula-node-lxc**                  | Base setup for LXC hypervisor Node (*not on RHEL 7*)                                                          |
 +------------------------------------------+---------------------------------------------------------------------------------------------------------------+
 | **opennebula-node-lxd**                  | Base setup for LXD hypervisor Node (*only on Ubuntu and Debian*)                                              |
 +------------------------------------------+---------------------------------------------------------------------------------------------------------------+
@@ -137,14 +130,14 @@ Available packages for OpenNebula clients, the Front-end and hypervisor Nodes:
 | **docker-machine-opennebula**            | OpenNebula driver for Docker Machine                                                                          |
 +------------------------------------------+---------------------------------------------------------------------------------------------------------------+
 
-There are also packages with debugging symbols for some platforms, e.g. ``openenbula-debuginfo`` on CentOS/RHEL and ``opennebula-dbgsym`` on Debian/Ubuntu. Other architecture-specific components might come with similarly named packages, please query your packaging database if necessary.
+There are also packages with debugging symbols for some platforms, e.g. ``openenbula-debuginfo`` on AlmaLinux/RHEL and ``opennebula-dbgsym`` on Debian/Ubuntu. Other architecture-specific components might come with similarly named packages, please query your packaging database if necessary.
 
 .. note::
 
-   There are a few differences in package names among distributions. Those with varying package names contain mostly integration libraries and since they are for general use on installation Hosts, their names are left to follow the distribution conventions. Above, you can find the CentOS/RHEL/Fedora specific packages prefixed with "*rpm:*" and Debian/Ubuntu specific packages prefixed with "*deb:*".
+   There are a few differences in package names among distributions. Those with varying package names contain mostly integration libraries and since they are for general use on installation Hosts, their names are left to follow the distribution conventions. Above, you can find the AlmaLinux/RHEL specific packages prefixed with "*rpm:*" and Debian/Ubuntu specific packages prefixed with "*deb:*".
 
-CentOS / RHEL / Fedora
-----------------------
+AlmaLinux / RHEL
+----------------
 
 Install all OpenNebula Front-end components by executing the following commands under a privileged user:
 
@@ -158,7 +151,7 @@ Install all OpenNebula Front-end components by executing the following commands 
 
 1. Install dependencies for :ref:`Docker Hub Marketplace <market_dh>`:
 
-- install Docker following the official documentation for `CentOS <https://docs.docker.com/engine/install/centos/>`_ or `Fedora <https://docs.docker.com/engine/install/fedora/>`_
+- install Docker following the official documentation `<https://docs.docker.com/engine/install/>`
 - add user ``oneadmin`` into group ``docker``:
 
 .. prompt:: bash # auto

--- a/source/installation_and_configuration/frontend_installation/opennebula_repository_configuration.rst
+++ b/source/installation_and_configuration/frontend_installation/opennebula_repository_configuration.rst
@@ -22,19 +22,19 @@ OpenNebula Systems provides an OpenNebula Enterprise Edition to customers with a
 
     You should have received the customer access token (username and password) to access these repositories. You have to substitute the appearance of ``<token>`` with your customer specific token in all instructions below.
 
-CentOS/RHEL
------------
+RHEL/AlmaLinux
+--------------
 
 To add the OpenNebula enterprise repository, execute the following as user ``root``:
 
-**CentOS/RHEL 7**
+**RHEL 7**
 
 .. prompt:: bash # auto
 
     # cat << "EOT" > /etc/yum.repos.d/opennebula.repo
     [opennebula]
     name=OpenNebula Enterprise Edition
-    baseurl=https://<token>@enterprise.opennebula.io/repo/6.2/CentOS/7/$basearch
+    baseurl=https://<token>@enterprise.opennebula.io/repo/6.2/RedHat/7/$basearch
     enabled=1
     gpgkey=https://downloads.opennebula.io/repo/repo.key
     gpgcheck=1
@@ -42,14 +42,29 @@ To add the OpenNebula enterprise repository, execute the following as user ``roo
     EOT
     # yum makecache fast
 
-**CentOS/RHEL 8**
+**RHEL 8**
 
 .. prompt:: bash # auto
 
     # cat << "EOT" > /etc/yum.repos.d/opennebula.repo
     [opennebula]
     name=OpenNebula Enterprise Edition
-    baseurl=https://<token>@enterprise.opennebula.io/repo/6.2/CentOS/8/$basearch
+    baseurl=https://<token>@enterprise.opennebula.io/repo/6.2/RedHat/8/$basearch
+    enabled=1
+    gpgkey=https://downloads.opennebula.io/repo/repo.key
+    gpgcheck=1
+    repo_gpgcheck=1
+    EOT
+    # yum makecache
+
+**AlmaLinux 8**
+
+.. prompt:: bash # auto
+
+    # cat << "EOT" > /etc/yum.repos.d/opennebula.repo
+    [opennebula]
+    name=OpenNebula Enterprise Edition
+    baseurl=https://<token>@enterprise.opennebula.io/repo/6.2/AlmaLinux/8/$basearch
     enabled=1
     gpgkey=https://downloads.opennebula.io/repo/repo.key
     gpgcheck=1
@@ -136,7 +151,7 @@ Community Edition
 
 The community edition of OpenNebula offers the full functionality of the Cloud Management Platform. You can configure the community repositories as follows:
 
-CentOS/RHEL/Fedora
+CentOS/RHEL
 ------------------
 
 To add OpenNebula repository, execute the following as user ``root``:

--- a/source/installation_and_configuration/opennebula_services/sunstone.rst
+++ b/source/installation_and_configuration/opennebula_services/sunstone.rst
@@ -336,7 +336,6 @@ The VM Templates can have an image logo to identify the guest OS. Edit ``/etc/on
     - { 'name': "Alpine Linux",    'path': "images/logos/alpine.png"}
     - { 'name': "ALT",             'path': "images/logos/alt.png"}
     - { 'name': "Arch Linux",      'path': "images/logos/arch.png"}
-    - { 'name': "CentOS",          'path': "images/logos/centos.png"}
     - { 'name': "Debian",          'path': "images/logos/debian.png"}
     - { 'name': "Fedora",          'path': "images/logos/fedora.png"}
     - { 'name': "FreeBSD",         'path': "images/logos/freebsd.png"}

--- a/source/integration_and_development/references/build_deps.rst
+++ b/source/integration_and_development/references/build_deps.rst
@@ -112,7 +112,7 @@ Debian 10
 * **ruby**
 * **scons**
 
-CentOS 8
+AlmaLinux 8
 ================================================================================
 
 * **gcc-c++**
@@ -138,29 +138,6 @@ CentOS 8
 * **sqlite-devel**
 * **systemd-devel**
 * **xmlrpc-c-devel**
-
-CentOS 7
-================================================================================
-
-* **gcc-c++**
-* **gnutls-devel**
-* **java-1.7.0-openjdk-devel**
-* **libcurl-devel**
-* **libjpeg-turbo-devel**
-* **libvncserver-devel**
-* **libxml2-devel**
-* **mysql-devel**
-* **openssh**
-* **openssl-devel**
-* **postgresql-devel**
-* **pkgconfig**
-* **ruby**
-* **scons**
-* **sqlite-devel**
-* **systemd-devel**
-* **xmlrpc-c**
-* **xmlrpc-c-devel**
-* **ws-commons-util**
 
 Arch
 ================================================================================

--- a/source/intro_release_notes/release_notes_enterprise/platform_notes_621.rst
+++ b/source/intro_release_notes/release_notes_enterprise/platform_notes_621.rst
@@ -27,7 +27,7 @@ Front-End Components
 | MariaDB or MySQL         | Version included in the Linux distribution             | :ref:`MySQL Setup <mysql>`                            |
 +--------------------------+--------------------------------------------------------+-------------------------------------------------------+
 | PostgreSQL               | 9.5+, Version included in the Linux distribution       | :ref:`PostgreSQL Setup <postgresql>`                  |
-|                          | (except RHEL/CentOS 7)                                 |                                                       |
+|                          | (except RHEL 7)                                        |                                                       |
 +--------------------------+--------------------------------------------------------+-------------------------------------------------------+
 | SQLite                   | Version included in the Linux distribution             | Default DB, no configuration needed                   |
 +--------------------------+--------------------------------------------------------+-------------------------------------------------------+
@@ -52,7 +52,7 @@ KVM Nodes
 | Debian                   | 10, 11                                                  | :ref:`KVM Driver <kvmg>`                |
 +--------------------------+---------------------------------------------------------+-----------------------------------------+
 | KVM/Libvirt              | Support for version included in the Linux distribution. | :ref:`KVM Node Installation <kvm_node>` |
-|                          | For CentOS/RHEL the packages from ``qemu-ev`` are used. |                                         |
+|                          | For RHEL the packages from ``qemu-ev`` are used.        |                                         |
 +--------------------------+---------------------------------------------------------+-----------------------------------------+
 
 LXC Nodes

--- a/source/intro_release_notes/upgrades/upgrading_single.rst
+++ b/source/intro_release_notes/upgrades/upgrading_single.rst
@@ -5,96 +5,96 @@ Upgrading Single Front-end Deployments
 ================================================================================
 
 .. If you are upgrading from a 6.0.x installation you only need to follow a reduced set of steps. If you are running a 5.12.x version or older, please check :ref:`these set of steps <upgrading_from_previous_extended_steps>` (some additional ones may apply, please review them at the end of the section).
-    
+
     .. important::
-    
+
         Users of the Community Edition of OpenNebula can upgrade from the previous stable version if they are running a non-commercial OpenNebula cloud. In order to access the migrator package a request needs to be made through this `online form <https://opennebula.io/get-migration>`__.
-    
+
     .. _upgrade_62:
-    
+
     Upgrading from 6.2.x
     ^^^^^^^^^^^^^^^^^^^^^
-    
+
     This section describes the installation procedure for systems that are already running a 6.0.x OpenNebula. The upgrade to OpenNebula |version| can be done directly following this section, you don't need to perform intermediate version upgrades. The upgrade will preserve all current users, hosts, resources and configurations.
-    
+
     When performing a minor upgrade OpenNebula adheres to the following convention to ease the process:
-    
+
       * No changes are made to the configuration files, so no configuration file will be changed during the upgrade.
       * Database versions are preserved, so no upgrade of the database schema is needed.
-    
+
     When a critical bug requires an exception to the previous rules it will be explicitly noted in this guide.
-    
+
     Upgrading a Federation and High Availability
     ================================================================================
-    
+
     You need to perform the following steps in all the HA nodes and all zones. You can upgrade the servers one by one to not incur any downtime.
-    
+
     Step 1 Stop OpenNebula Services
     ===============================
-    
+
     Before proceeding, make sure you don't have any VMs in a transient state (prolog, migr, epil, save). Wait until these VMs get to a final state (run, suspended, stopped, done). Check the :ref:`Managing Virtual Machines guide <vm_guide_2>` for more information on the VM life-cycle.
-    
+
     Now you are ready to stop OpenNebula and any other related services you may have running, e.g. Sunstone or OneFlow. It's preferable to use the system tools, like `systemctl` or `service` as `root` in order to stop the services.
-    
+
     Step 2 Upgrade Front-end to the New Version
     ===========================================
-    
+
     Upgrade the OpenNebula software using the package manager of your OS. Refer to the :ref:`Single Front-end Installation guide <frontend_installation>` for a complete list of the OpenNebula packages installed on your system. Package repos need to be pointing to the latest version (|version|).
-    
-    For example, in CentOS/RHEL simply execute:
-    
+
+    For example, in RHEL simply execute:
+
     .. prompt:: text # auto
-    
+
         # yum upgrade opennebula
-    
+
     For Debian/Ubuntu use:
-    
+
     .. prompt:: text # auto
-    
+
        # apt-get update
        # apt-get install --only-upgrade opennebula
-    
+
     Step 3 Upgrade Hypervisors to the New Version
     =============================================
-    
+
     You can skip this section for vCenter Hosts.
-    
+
     Upgrade the OpenNebula node KVM or LXD packages, using the package manager of your OS.
-    
+
     For example, in a rpm-based Linux distribution simply execute:
-    
+
     .. prompt:: text # auto
-    
+
        # yum upgrade opennebula-node-kvm
-    
+
     For deb-based distros use:
-    
+
     .. prompt:: text # auto
-    
+
        # apt-get update
        # apt-get install --only-upgrade opennebula-node-kvm
-    
+
     .. note:: If you are using LXD the package is ``opennebula-node-lxd``.
-    
+
     Update the Drivers
     ==================
-    
+
     You should now be able to start OpenNebula as usual, running ``service opennebula start`` as ``root``. At this point, as ``oneadmin`` user, execute ``onehost sync`` to update the new drivers in the Hosts.
-    
+
     .. note:: You can skip this step if you are not using KVM Hosts, or any Hosts that use remote monitoring probes.
-    
+
     Testing
     =======
-    
+
     OpenNebula will continue the monitoring and management of your previous Hosts and VMs.
-    
+
     As a measure of caution, look for any error messages in oned.log, and check that all drivers are loaded successfully. After that, keep an eye on oned.log while you issue the onevm, onevnet, oneimage, oneuser, onehost **list** commands. Try also using the **show** subcommand for some resources.
-    
+
     Restoring the Previous Version
     ==============================
-    
+
     If for any reason you need to restore your previous OpenNebula, simply uninstall OpenNebula |version|, and install again your previous version. After that, update the drivers if needed, as outlined in Step 12.
-             
+
 .. _upgrading_from_previous_extended_steps:
 
 Upgrading from 5.6.x+
@@ -146,7 +146,7 @@ Ubuntu/Debian
     # apt-get update
     # apt-get install --only-upgrade opennebula opennebula-sunstone opennebula-gate opennebula-flow opennebula-provision python3-pyone
 
-CentOS/RHEL
+RHEL
 
 .. prompt:: text # auto
 
@@ -179,7 +179,7 @@ Community Edition
 
 There is an additoinal step if you are upgrading OpenNebula CE. After you get the `opennebula-migration-community package <https://opennebula.io/get-migration>`__, you need to install it in the OpenNebula Front-end.
 
-CentOS/RHEL
+RHEL
 ~~~~~~~~~~~
 
 .. prompt:: bash # auto
@@ -367,7 +367,7 @@ If upgrading the LXD drivers on Ubuntu
 
     # apt-get install --only-upgrade opennebula-node-lxd
 
-CentOS
+RHEL
 
 .. prompt:: text # auto
 

--- a/source/management_and_operations/edge_cluster_management/onprem_cluster.rst
+++ b/source/management_and_operations/edge_cluster_management/onprem_cluster.rst
@@ -78,7 +78,7 @@ Before we start we need to prepare the hosts for our on-prem cluster. We just ne
     $ ssh root@host01 cat /etc/centos-release
     Warning: Permanently added 'host01,10.4.4.100' (ECDSA) to the list of known hosts.
     CentOS Linux release 8.3.2011
-    
+
 
     $  ssh root@host02 cat /etc/centos-release
     Warning: Permanently added 'host02,10.4.4.101' (ECDSA) to the list of known hosts.
@@ -229,10 +229,10 @@ The final step will be adding a network interface to the template just created (
 Now we can create the VM from this template:
 
 .. prompt:: bash $ auto
-    
+
     $ onetemplate instantiate 3
     VM ID:10
-    
+
     $ onevm show 10
     VIRTUAL MACHINE 10 INFORMATION
     ID                  : 10

--- a/source/management_and_operations/end-user_web_interfaces/sunstone_labels.rst
+++ b/source/management_and_operations/end-user_web_interfaces/sunstone_labels.rst
@@ -20,7 +20,7 @@ This filter is **also available in the cloud view** inside the virtual machine c
 
 |labels_cloud|
 
-To create a **label hierarchy**, use slash character: ``/``. For example, you could have the labels ``Linux/Ubuntu`` and ``Linux/Centos``.
+To create a **label hierarchy**, use slash character: ``/``. For example, you could have the labels ``Linux/Ubuntu`` and ``Linux/RedHat``.
 
 .. _suns_views_labels_behavior:
 
@@ -80,7 +80,7 @@ You can separate them per groups of users or introduce them into the default sec
     labels_groups:
         oneadmin:
             - Linux/Ubuntu
-            - Linux/Centos
+            - Linux/RedHat
         default:
             - default
 

--- a/source/management_and_operations/references/config/roles.rst
+++ b/source/management_and_operations/references/config/roles.rst
@@ -93,7 +93,7 @@ Parameter                               Default                                 
 ``opennebula_repository_base``          ``https://downloads.opennebula.io/repo/``  Repository of the OpenNebula packages
                                         ``{{ opennebula_repository_version }}``
 ``opennebula_repository_gpgcheck``      yes                                        Enable GPG check for the packages
-``opennebula_repository_repo_gpgcheck`` yes                                        Enable GPG check for the repos (RHEL/CentOS only)
+``opennebula_repository_repo_gpgcheck`` yes                                        Enable GPG check for the repos (RHEL/AlmaLinux only)
 ======================================= ========================================== ===========
 
 Role opennebula-ssh

--- a/source/open_cluster_deployment/firecracker_node/firecracker_node_installation.rst
+++ b/source/open_cluster_deployment/firecracker_node/firecracker_node_installation.rst
@@ -17,8 +17,8 @@ Step 1. Add OpenNebula Repositories
 Step 2. Installing the Software
 ===============================
 
-Installing on CentOS/RHEL
--------------------------
+Installing on AlmaLinux/RHEL
+----------------------------
 
 .. include:: ../common_node/epel.txt
 
@@ -45,8 +45,8 @@ Execute the following commands to install the OpenNebula Firecracker Node packag
 
 For further configuration check the specific :ref:`guide <fcmg>`.
 
-Step 3. Disable SELinux on CentOS/RHEL (Optional)
-=================================================
+Step 3. Disable SELinux on AlmaLinux/RHEL (Optional)
+====================================================
 
 .. include:: ../common_node/selinux.txt
 

--- a/source/open_cluster_deployment/kvm_node/kvm_node_installation.rst
+++ b/source/open_cluster_deployment/kvm_node/kvm_node_installation.rst
@@ -35,19 +35,12 @@ Execute the following commands to install the OpenNebula KVM Node package and re
 
 For further configuration, check the specific :ref:`guide <kvmg>`.
 
-Optional: Newer QEMU/KVM (only CentOS/RHEL 7)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Optional: Newer QEMU/KVM (only RHEL 7)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. note::
 
     You may benefit from using the more recent and feature-rich enterprise QEMU/KVM release. The differences between the base (``qemu-kvm``) and enterprise (``qemu-kvm-rhev`` on RHEL or ``qemu-kvm-ev`` on CentOS) packages are described on the `Red Hat Customer Portal <https://access.redhat.com/solutions/629513>`__.
-
-    On **CentOS 7**, the enterprise packages are part of the separate repository. To replace the base packages, follow these steps:
-
-    .. prompt:: bash # auto
-
-        # yum -y install centos-release-qemu-ev
-        # yum -y install qemu-kvm-ev
 
     On **RHEL 7**, you need a paid subscription to the Red Hat Virtualization (RHV) or Red Hat OpenStack (RHOS) products license only for the Red Hat Enterprise. Linux isn't enough! You have to check the RHV `Installation Guide <https://access.redhat.com/documentation/en-us/red_hat_virtualization/>`__ for your licensed version. Usually, the following commands should enable and install the enterprise packages:
 

--- a/source/open_cluster_deployment/lxc_node/lxc_node_installation.rst
+++ b/source/open_cluster_deployment/lxc_node/lxc_node_installation.rst
@@ -17,8 +17,8 @@ Step 1. Add OpenNebula Repositories
 Step 2. Installing the Software
 ===============================
 
-Installing on CentOS/RHEL
--------------------------
+Installing on AlmaLinux/RHEL
+----------------------------
 
 .. include:: ../common_node/epel.txt
 
@@ -45,8 +45,8 @@ Execute the following commands to install the OpenNebula LXC Node package:
 
 For further configuration check the specific :ref:`guide <lxcmg>`.
 
-Step 3. Disable SELinux on CentOS/RHEL (Optional)
-=================================================
+Step 3. Disable SELinux on AlmaLinux/RHEL (Optional)
+====================================================
 
 .. include:: ../common_node/selinux.txt
 

--- a/source/quick_start/usage_basics/running_containers.rst
+++ b/source/quick_start/usage_basics/running_containers.rst
@@ -82,7 +82,7 @@ Now you need to select a datastore. Taking into account we are only going to run
 
 The appliance will be ready when the image in ``Storage --> Images`` (called "wordpress") switches to READY from its LOCKED state.
 
-You need to modify the Wordpress VM template. Proceed to the ``Templates --> VMs`` tab and select the Wordpress VM template. Click on update, proceed to the Network tab and select the aws-cluster-public network. 
+You need to modify the Wordpress VM template. Proceed to the ``Templates --> VMs`` tab and select the Wordpress VM template. Click on update, proceed to the Network tab and select the aws-cluster-public network.
 
 |wordpress_public_network|
 
@@ -109,9 +109,9 @@ Now you need to select a datastore. Taking into account we are only going to run
 
 |aws_cluster_images_datastore_mariadb|
 
-The appliance will be ready when the image in ``Storage --> Images`` (called "mariadb") switches to READY from its LOCKED state. 
+The appliance will be ready when the image in ``Storage --> Images`` (called "mariadb") switches to READY from its LOCKED state.
 
-You need to modify the Wordpress VM template. Proceed to the ``Templates --> VMs`` tab and select the Wordpress VM template. Click on update, proceed to the Network tab and select the aws-cluster-public network. 
+You need to modify the Wordpress VM template. Proceed to the ``Templates --> VMs`` tab and select the Wordpress VM template. Click on update, proceed to the Network tab and select the aws-cluster-public network.
 
 |mariadb_public_network|
 
@@ -134,7 +134,7 @@ Write "wordpress" as the name of the service and in the section ``Advanced servi
 
 |wordpress_service_template_create|
 
-Then, you need to add two roles to the service: one role for DB and one for Wordpress. Go to the ``Roles`` section of the template, write db in the ``Role name`` input text and select the MariaDB VM template previously created. 
+Then, you need to add two roles to the service: one role for DB and one for Wordpress. Go to the ``Roles`` section of the template, write db in the ``Role name`` input text and select the MariaDB VM template previously created.
 
 |mariadb_oneflow_role|
 
@@ -142,7 +142,7 @@ Then click on the + sign close to ``Roles`` to create a new role. Write wordpres
 
 |wordpress_oneflow_role|
 
-Once you have finished, click the green ``Create`` button. 
+Once you have finished, click the green ``Create`` button.
 
 Now go to the ``Instances --> Services`` tab, click on the green + sign and create a new service selecting the oneflow service template named Wordpress.
 


### PR DESCRIPTION
I consider the time between 6.2.1 EE and first CE release transitional, so at some places related solely to CE I left CentOS mentioned.

Where the documentation is general (no CE/EE mentioned) and where it is related to the supported OS, there I removed CentOS.

I still left it only there where it's used as an image example and also in MiniONE/oneprovision docs where update is pending.