### PR TITLE
B OpenNebula/one#5451: Clean VCPU_MAX and MEMORY_MAX

### DIFF
--- a/source/intro_release_notes/release_notes_enterprise/resolved_issues_622.rst
+++ b/source/intro_release_notes/release_notes_enterprise/resolved_issues_622.rst
@@ -12,3 +12,4 @@ The following new features has been backported to 6.2.2:
 The following issues has been solved in 6.2.2:
 
 - `Fix Sunstone does not use remote host for memcache-dalli <https://github.com/OpenNebula/one/issues/5156>`__.
+- `Clean VCPU_MAX and MEMORY_MAX when disabling hot resize <https://github.com/OpenNebula/one/issues/5451>`__.


### PR DESCRIPTION
This PR applies to:
- one-6.2-maintenance

Signed-off-by: Frederick Borges <fborges@opennebula.io>