### PR TITLE
Fixing CentOS 7 Opennebula repository URL (6.2 instead of 6.0).

### DIFF
--- a/source/installation_and_configuration/frontend_installation/opennebula_repository_configuration.rst
+++ b/source/installation_and_configuration/frontend_installation/opennebula_repository_configuration.rst
@@ -34,7 +34,7 @@ To add the OpenNebula enterprise repository, execute the following as user ``roo
     # cat << "EOT" > /etc/yum.repos.d/opennebula.repo
     [opennebula]
     name=OpenNebula Enterprise Edition
-    baseurl=https://<token>@enterprise.opennebula.io/repo/6.0/CentOS/7/$basearch
+    baseurl=https://<token>@enterprise.opennebula.io/repo/6.2/CentOS/7/$basearch
     enabled=1
     gpgkey=https://downloads.opennebula.io/repo/repo.key
     gpgcheck=1


### PR DESCRIPTION
In the documentation, only the CentOS 7 repo code shows 6.0 instead of 6.2.