### PR TITLE
Updating some 6.2 references to 6.4.0

### DIFF
--- a/source/installation_and_configuration/frontend_installation/install.rst
+++ b/source/installation_and_configuration/frontend_installation/install.rst
@@ -44,7 +44,7 @@ Not all OpenNebula dependencies are in base distribution repositories. On select
     # yum -y install epel-release
     # yum -y install centos-release-scl-rh
 
-**AlmaLinux 8 (6.2.1 EE only)**
+**AlmaLinux 8 (6.4.0 EE only)**
 
 .. prompt:: bash # auto
 

--- a/source/installation_and_configuration/frontend_installation/opennebula_repository_configuration.rst
+++ b/source/installation_and_configuration/frontend_installation/opennebula_repository_configuration.rst
@@ -135,11 +135,11 @@ and then continue with repository configuration:
 
 .. note::
 
-   You can point to a specific 6.2.x version by changing the occurrence of shorter version 6.2 in any of the above commands to the particular full 3 components version number (X.Y.Z). For instance, to point to version 6.2.1 on Ubuntu 18.04, use the following command instead:
+   You can point to a specific 6.4.x version by changing the occurrence of shorter version 6.4 in any of the above commands to the particular full 3 components version number (X.Y.Z). For instance, to point to version 6.4.1 on Ubuntu 18.04, use the following command instead:
 
     .. prompt:: bash # auto
 
-       # echo "deb https://<token>@enterprise.opennebula.io/repo/6.2.1/Ubuntu/18.04 stable opennebula" > /etc/apt/sources.list.d/opennebula.list
+       # echo "deb https://<token>@enterprise.opennebula.io/repo/6.4.1/Ubuntu/18.04 stable opennebula" > /etc/apt/sources.list.d/opennebula.list
        # apt-get update
 
 Following Debian 10 and Ubuntu 16.04, it's now possible (and recommended) to store a customer token in a separate file to the repository configuration. If you choose to store the repository credentials separately, you need to avoid using the ``<token>@`` part in the repository definitions above. You should create a new file ``/etc/apt/auth.conf.d/opennebula.conf`` with the following structure and replace the ``<user>`` and ``<password>`` parts with the customer credentials you have received:
@@ -169,7 +169,7 @@ To add OpenNebula repository, execute the following as user ``root``:
     # cat << "EOT" > /etc/yum.repos.d/opennebula.repo
     [opennebula]
     name=OpenNebula Community Edition
-    baseurl=https://downloads.opennebula.io/repo/6.2/CentOS/7/$basearch
+    baseurl=https://downloads.opennebula.io/repo/6.4.0/CentOS/7/$basearch
     enabled=1
     gpgkey=https://downloads.opennebula.io/repo/repo.key
     gpgcheck=1
@@ -184,7 +184,7 @@ To add OpenNebula repository, execute the following as user ``root``:
     # cat << "EOT" > /etc/yum.repos.d/opennebula.repo
     [opennebula]
     name=OpenNebula Community Edition
-    baseurl=https://downloads.opennebula.io/repo/6.2/CentOS/8/$basearch
+    baseurl=https://downloads.opennebula.io/repo/6.4.0/CentOS/8/$basearch
     enabled=1
     gpgkey=https://downloads.opennebula.io/repo/repo.key
     gpgcheck=1
@@ -230,14 +230,14 @@ First, add the repository signing GPG key on the Front-end by executing as user 
 
 .. prompt:: bash # auto
 
-    # echo "deb https://downloads.opennebula.io/repo/6.2/Debian/10 stable opennebula" > /etc/apt/sources.list.d/opennebula.list
+    # echo "deb https://downloads.opennebula.io/repo/6.4.0/Debian/10 stable opennebula" > /etc/apt/sources.list.d/opennebula.list
     # apt-get update
 
 **Debian 11**
 
 .. prompt:: bash # auto
 
-    # echo "deb https://downloads.opennebula.io/repo/6.2/Debian/11 stable opennebula" > /etc/apt/sources.list.d/opennebula.list
+    # echo "deb https://downloads.opennebula.io/repo/6.4.0/Debian/11 stable opennebula" > /etc/apt/sources.list.d/opennebula.list
     # apt-get update
 
 
@@ -245,12 +245,12 @@ First, add the repository signing GPG key on the Front-end by executing as user 
 
 .. prompt:: bash # auto
 
-    # echo "deb https://downloads.opennebula.io/repo/6.2/Ubuntu/18.04 stable opennebula" > /etc/apt/sources.list.d/opennebula.list
+    # echo "deb https://downloads.opennebula.io/repo/6.4.0/Ubuntu/18.04 stable opennebula" > /etc/apt/sources.list.d/opennebula.list
     # apt-get update
 
 **Ubuntu 20.04**
 
 .. prompt:: bash # auto
 
-    # echo "deb https://downloads.opennebula.io/repo/6.2/Ubuntu/20.04 stable opennebula" > /etc/apt/sources.list.d/opennebula.list
+    # echo "deb https://downloads.opennebula.io/repo/6.4.0/Ubuntu/20.04 stable opennebula" > /etc/apt/sources.list.d/opennebula.list
     # apt-get update


### PR DESCRIPTION
Half of the repo links were stills et to 6.2, this updates those to 6.4 as well as the explanation of subversions note.

This appears to apply to branch one-6.4-maintenance as well

Signed-off-by: Neal Hansen <nhansen@opennebula.io>