### PR TITLE
B OpenNebula/one#5854: Check history VM_MAD instead hypervisor for vm migration

### DIFF
--- a/source/intro_release_notes/release_notes_enterprise/resolved_issues_641.rst
+++ b/source/intro_release_notes/release_notes_enterprise/resolved_issues_641.rst
@@ -25,3 +25,4 @@ The following issues has been solved in 6.4.1:
 - `Fix quota rollback if command 'onevm snapshot-create' fails <https://github.com/OpenNebula/one/issues/5852>`__.
 - `Fix double VM_POOL element in onevm list -x <https://github.com/OpenNebula/one/issues/5858>`__.
 - `Fix bug in send_to_monitor function <https://github.com/OpenNebula/one/issues/5855>`__.
+- `Get hypervisor from VM history instead HYPERVISOR attribute for VM migration <https://github.com/OpenNebula/one/issues/5854>`__.


### PR DESCRIPTION
This PR applies to:
- one-6.4-maintenance

Signed-off-by: Frederick Ernesto Borges Noronha <fborges@opennebula.io>