### PR TITLE
M #-: Clarify permissions for new resources

### DIFF
--- a/source/management_and_operations/users_groups_management/chmod.rst
+++ b/source/management_and_operations/users_groups_management/chmod.rst
@@ -97,7 +97,13 @@ Let's see some examples:
 Setting Default Permissions with umask
 --------------------------------------
 
-The default permissions given to newly created resources can be set:
+The default permissions given to newly created resources are:
+
+- 666 for regular users
+- 660 for regular users if ``ENABLE_OTHER_PERMISSIONS`` attribute is set to ``NO`` in ``/etc/one/oned.conf``
+- 777 for oneadmin user and group
+
+These permissions are reduced by the UMASK, which can be set:
 
 -  Globally, with the **DEFAULT\_UMASK** attribute in :ref:`oned.conf <oned_conf>`
 -  Individually for each User, using the :ref:`oneuser umask command <cli>`.


### PR DESCRIPTION
Merge to one-6.4 and master

While checking [this issue](https://github.com/OpenNebula/one/issues/1380), I found out I don't know, why the user doesn't have admin permissions for newly created object, if umask is 017. I haven't found it in documentation, must search in code. Added these default permissions to UMASK section.