### PR TITLE
M #-: context restricted dirs documentation

### DIFF
--- a/source/installation_and_configuration/opennebula_services/oned.rst
+++ b/source/installation_and_configuration/opennebula_services/oned.rst
@@ -44,6 +44,8 @@ The OpenNebula Daemon configuration file can be found in ``/etc/one/oned.conf`` 
 
 -  ``VM_SUBMIT_ON_HOLD``: Forces VMs to be created on hold state instead of pending. Values: ``YES`` or ``NO``.
 -  ``API_LIST_ORDER``: Sets order (by ID) of elements in list API calls (e.g. ``onevm list``). Values: ``ASC`` (ascending order) or ``DESC`` (descending order).
+-  ``CONTEXT_RESTRICTED_DIRS``: List of space separated directories, which can't be used in ``CONTEXT/FILES`` attribute.
+-  ``CONTEXT_SAFE_DIRS``: List of space separated directories, which allows use of subdirectories from ``CONTEXT_RESTRICTED_DIRS``.
 -  ``LOG``: Configure the logging system
 
    -  ``SYSTEM``: Can be either ``file`` (default), ``syslog`` or ``std``
@@ -61,6 +63,8 @@ The OpenNebula Daemon configuration file can be found in ``/etc/one/oned.conf`` 
 +----------------+---------------+
 | ``3``          | **DEBUG**     |
 +----------------+---------------+
+
+Add CONTEXT_RESTRICTED_DIRS and CONTEXT_SAFE_DIRS here
 
 Example of this section:
 

--- a/source/installation_and_configuration/opennebula_services/oned.rst
+++ b/source/installation_and_configuration/opennebula_services/oned.rst
@@ -64,8 +64,6 @@ The OpenNebula Daemon configuration file can be found in ``/etc/one/oned.conf`` 
 | ``3``          | **DEBUG**     |
 +----------------+---------------+
 
-Add CONTEXT_RESTRICTED_DIRS and CONTEXT_SAFE_DIRS here
-
 Example of this section:
 
 .. code-block:: bash

--- a/source/management_and_operations/references/template.rst
+++ b/source/management_and_operations/references/template.rst
@@ -625,9 +625,10 @@ Context information is passed to the Virtual Machine via an ISO mounted as a par
 | ``VARIABLE``                      | Variables that store values related to this virtual machine or others . The name                | O                            | O       |
 |                                   | of the variable is arbitrary (in the example, we use hostname).                                 |                              |         |
 +-----------------------------------+-------------------------------------------------------------------------------------------------+------------------------------+---------+
-| ``FILES \*``                      | space-separated list of paths to include in context device.                                     | O                            | O       |
+| ``FILES``                         | Space-separated list of paths to include in context device. The location of the files are       | O                            | O       |
+|                                   | restricted by the ``CONTEXT_RESTRICTED_DIRS`` in :ref:`oned.conf <oned_conf>`                   |                              |         |
 +-----------------------------------+-------------------------------------------------------------------------------------------------+------------------------------+---------+
-| ``FILES_DS``                      | space-separated list of File images to include in context device. (Not supported                | O                            | O       |
+| ``FILES_DS``                      | Space-separated list of File images to include in context device. (Not supported                | O                            | O       |
 |                                   | for vCenter)                                                                                    |                              |         |
 +-----------------------------------+-------------------------------------------------------------------------------------------------+------------------------------+---------+
 | ``INIT_SCRIPTS``                  | If the VM uses the OpenNebula contextualization package the init.sh file is                     | O                            | O       |


### PR DESCRIPTION
Merge to master and one-6.4-maintanance

By default restricted dirs contains only `/etc`, so I think we don't need to add this to compatibility guide