### PR TITLE
M #: Add missing build dep

### DIFF
--- a/source/integration_and_development/references/build_deps.rst
+++ b/source/integration_and_development/references/build_deps.rst
@@ -32,6 +32,7 @@ Ubuntu 20.04
 * **libsystemd-dev**
 * **libws-commons-util-java**
 * **libxml2-dev**
+* **libxmlrpc-c++8-dev**
 * **libxslt1-dev**
 * **libcurl4-openssl-dev**
 * **libcurl4**


### PR DESCRIPTION
scons fails to execute because of the missing package on the dependency list.

Applies as well to
- master
- one-6.4 non-maintenance