### PR TITLE
B OpenNebula/terraform-provider-opennebula#331: update what's new

### DIFF
--- a/source/intro_release_notes/release_notes/whats_new.rst
+++ b/source/intro_release_notes/release_notes/whats_new.rst
@@ -71,6 +71,7 @@ Other Issues Solved
 - `Fix oned.conf debug levels only covers 0-3, but oned has 0-5 levels <https://github.com/OpenNebula/one/issues/5820>`__.
 - `Fix OpenNebula (oned) sometimes fails to remove lock file on exit and refuses to start  <https://github.com/OpenNebula/one/issues/5189>`__.
 - `Fix onedb fsck does not detect discrepancy between UID / GID in database for resources (XML) <https://github.com/OpenNebula/one/issues/1165>`__.
+- `Fix default scope for goca to gather all visible objects rather than just those owned by the user <https://github.com/OpenNebula/terraform-provider-opennebula/issues/331>`__.
 
 Features Backported to 6.4.x
 ================================================================================


### PR DESCRIPTION
Inserting the changes made to goca to the documentation

This should apply to all current releases, one-5.12, one-6.0, one-6.2, one-6.4

PR on one-ee: https://github.com/OpenNebula/one-ee/pull/2294

Signed-off-by: Neal Hansen <nhansen@opennebula.io>