### PR TITLE
F OpenNebula/one#5681: Doc for block context devices

### DIFF
--- a/source/intro_release_notes/release_notes/whats_new.rst
+++ b/source/intro_release_notes/release_notes/whats_new.rst
@@ -36,6 +36,7 @@ OpenNebula Core
 - For security reason restrict paths in ``CONTEXT/FILES`` by ``CONTEXT_RESTRICTED_DIRS`` (with exceptions in ``CONTEXT_SAFE_DIRS``) configured in :ref:`oned.conf <oned_conf>`
 - :ref:`PCI Passthrough devices can be selected by its address <pci_usage>` to support use cases that requires specific devices to be passed to the virtual machine. This by-passes the PCI scheduler of OpenNebula.
 - `Enforce VNC password length up to 8 symbols, since the VNC password can never be more than 8 characters long in libvirt <https://github.com/OpenNebula/one/issues/5842>`__.
+- `Support for block context devices <https://github.com/OpenNebula/one/issues/5681>`__. System Datastore can include ``CONTEXT_DISK_TYPE`` to specify the type (``FILE`` or ``BLOCK``) of the context CD's.
 
 Networking
 ================================================================================

--- a/source/management_and_operations/storage_management/datastores.rst
+++ b/source/management_and_operations/storage_management/datastores.rst
@@ -165,6 +165,8 @@ Also, there are a set of common attributes that can be used in any Datastore to 
 +------------------------------+----------------------------------------------------------------------------------------------------------------------------------+
 | ``COMPATIBLE_SYS_DS``        | Only for Image Datastores. Set the System Datastores that can be used with an Image Datastore, e.g. "0,100"                      |
 +------------------------------+----------------------------------------------------------------------------------------------------------------------------------+
+| ``CONTEXT_DISK_TYPE``        | Specifies the disk type used for context devices (``BLOCK`` or ``FILE``). If not specified, ``FILE`` is used by default.         |
++------------------------------+----------------------------------------------------------------------------------------------------------------------------------+
 
 The Files & Kernels Datastore is an special datastore type to store plain files to be used as kernels, ram-disks or context files. :ref:`See here to learn how to define them <file_ds>`.
 


### PR DESCRIPTION
Attribute `CONTEXT_DISK_TYPE` added to datastore attributes in the datastore documentation.