### PR TITLE
M #~: Fix to show nginx configuration example

### DIFF
--- a/source/installation_and_configuration/large-scale_deployment/sunstone_for_large_deployments.rst
+++ b/source/installation_and_configuration/large-scale_deployment/sunstone_for_large_deployments.rst
@@ -482,7 +482,7 @@ You will need to configure a new virtual host in nginx. Depending on the operati
 
 -  A sample ``cloudserver.org`` virtual host is presented next:
 
-.. code-block::bash
+.. code-block:: bash
 
     #### OpenNebula Sunstone upstream
     upstream sunstone  {


### PR DESCRIPTION
This PR applies to:
- master
- one-6.6
- one-6.4
- one-6.2: This is to have the previous documentation without errors
- one-6.6-maintenance
- one-6.4-maintenance
- one-6.2-maintenance: This is to have the previous documentation without errors (IDK if this is needed)