### PR TITLE
B #-: Add details about cgroups in host OS updates

### DIFF
--- a/source/intro_release_notes/release_notes/platform_notes.rst
+++ b/source/intro_release_notes/release_notes/platform_notes.rst
@@ -261,6 +261,22 @@ The following items apply to all distributions:
 
     DISK = [ driver = "qcow2", cache = "writethrough" ]
 
+* Most Linux distributions using a kernel 5.X (i.e. Debian 11) mount cgroups v2 via systemd natively. If you have hosts with a previous version of the distribution mounting cgroups via fstab or in v1 compatibility mode (i.e. Debian 10) and their libvirt version is <5.5, during the migration of VMs from older hosts to new ones you can experience errors like
+
+.. code::
+
+    WWW MMM DD hh:mm:ss yyyy: MIGRATE: error: Unable to write to '/sys/fs/cgroup/machine.slice/machine-qemu/..../cpu.weight': Numerical result out of range Could not migrate VM_UID to HOST ExitCode: 1
+
+This happens in every single VM migration from a host with the previous OS version to a host with the new one. 
+
+To solve this, there are 2 options: Delete the VM and recreate it scheduled in a host with the new OS version or mount cgroups in v1 compatibility mode in the nodes with the new OS version. To do this
+
+    1. Edit the bootloader default options (normally under ``/etc/defaults/grub.conf``)
+    2. Modify the default commandline for the nodes (usually ``GRUB_CMDLINE_LINUX="..."``) and add the option ``systemd.unified_cgroup_hierarchy=0``
+    3. Recreate the grub configuration file (in most cases executing a ``grub-mkconfig -o /boot/grub/grub.cfg``)
+    4. Reboot the host. The change will be persistent if the kernel is updated
+
+
 RedHat 8 Platform Notes
 --------------------------------------------------------------------------------
 


### PR DESCRIPTION
Found this problem for VM migrations in case a host is updated from Debian 10 to Debian 11.
It can apply to other distribution updates