### PR TITLE
M #-: Update gpg key repo adding on Ubuntu 22.04

### DIFF
--- a/source/installation_and_configuration/frontend_installation/opennebula_repository_configuration.rst
+++ b/source/installation_and_configuration/frontend_installation/opennebula_repository_configuration.rst
@@ -75,6 +75,12 @@ First, add the repository signing GPG key on the Front-end by executing as user 
 
     # wget -q -O- https://downloads.opennebula.io/repo/repo2.key | apt-key add -
 
+.. important:: If you are using Ubuntu 22.04, ``apt-key`` to add signing GPG keys is about to be deprecated. Execute the following:
+
+    .. prompt:: bash # auto
+    
+       # wget -q -O- https://downloads.opennebula.io/repo/repo2.key | gpg --dearmor > /etc/apt/trusted.gpg.d/opennebula.gpg
+
 and then continue with repository configuration:
 
 **Debian 10**


### PR DESCRIPTION
Can be added to all the versions that support Ubuntu 22.04

- release-6.6.0
- release-6.6.1
- master
