### PR TITLE
F OpenNebula/one#6267: improve ALLOW_ORPHANS documentation

### DIFF
--- a/source/installation_and_configuration/opennebula_services/oned.rst
+++ b/source/installation_and_configuration/opennebula_services/oned.rst
@@ -511,7 +511,12 @@ The configuration for each driver is defined in the ``TM_MAD_CONF`` section.
 
 - ``DS_MIGRATE``: set to ``YES`` if system datastore migrations are allowed for this TM. Only useful for system datastore TMs.
 
-- ``ALLOW_ORPHANS``: Whether snapshots can live without parents. It allows three values: ``YES``, ``NO`` and ``MIXED``. The last mode, ``MIXED``, allows the creation of orphan snapshots but takes into account some dependencies which can appear after a revert snapshot action on Ceph datastores.
+- ``ALLOW_ORPHANS``: Whether snapshots can live without parents:
+
+   -  ``YES``: The snapshot will be attempted to be deleted even if it has children
+   -  ``NO``: The snapshot will not be attempted to be deleted if it has children
+   -  ``MIXED``: Creates children snapshots from the current active(last recovered) snapshot.  This also takes into account some dependencies which can appear after a revert snapshot action in Ceph datastores.
+   -  ``FORMAT``: Allows orphans based on the image format in a ``SHARED`` datastore. For ``QCOW2`` this acts as ``NO`` and for ``RAW`` this acts as ``YES``
 
 Sample configuration:
 


### PR DESCRIPTION
Clarifies the available values for the ALLOW_ORPHANS attribute for datastores in the documentation.

This should apply to 6.0 and up.