### PR TITLE
F OpenNebula/One#6211: Fix datastore ignores cluster id

### DIFF
--- a/source/intro_release_notes/release_notes/whats_new.rst
+++ b/source/intro_release_notes/release_notes/whats_new.rst
@@ -59,6 +59,7 @@ Other Issues Solved
 - `Updated some ruby deprecated methods incompatible with newer ruby releases <https://github.com/OpenNebula/one/issues/6246>`__.
 - `Fix issue with block device backed disks causing libvirt to fail to boot a VM <https://github.com/OpenNebula/one/issues/6212>`__.
 - `Fix issue when resuming a VM in 'pmsuspended' state in virsh <https://github.com/OpenNebula/one/issues/5793>`__.
+- `Fix issue datastore creation ignores cluster selection <https://github.com/OpenNebula/one/issues/6211>`__.
 
 Features Backported to 6.6.x
 ================================================================================


### PR DESCRIPTION
this PR applies to:
- master