### PR TITLE
M #-: Add udev rule for PCI passthrough permission

### DIFF
--- a/source/open_cluster_deployment/kvm_node/pci_passthrough.rst
+++ b/source/open_cluster_deployment/kvm_node/pci_passthrough.rst
@@ -144,8 +144,7 @@ In our example our cards have the groups 45, 46, 58 and 59 so we add this config
 
 .. note::
 
-  There may be permissions problems if ``/dev/vfio`` devices are not owned by ``oneadmin:kvm``. In this cases, a udev rule like
-  ``SUBSYSTEM=="vfio", GROUP="kvm", OWNER="oneadmin"`` will set up the needed owner:group for them to work
+  There may be permissions problems if ``/dev/vfio`` devices are not owned by ``oneadmin:kvm``. In this cases, a udev rule like ``SUBSYSTEM=="vfio", GROUP="kvm", OWNER="oneadmin"`` will set up the needed owner:group for them to work
 
 
 Driver Configuration

--- a/source/open_cluster_deployment/kvm_node/pci_passthrough.rst
+++ b/source/open_cluster_deployment/kvm_node/pci_passthrough.rst
@@ -142,6 +142,12 @@ In our example our cards have the groups 45, 46, 58 and 59 so we add this config
 
 .. _pci_config:
 
+.. note::
+
+  There may be permissions problems if ``/dev/vfio`` devices are not owned by ``oneadmin:kvm``. In this cases, a udev rule like
+  ``SUBSYSTEM=="vfio", GROUP="kvm", OWNER="oneadmin"`` will set up the needed owner:group for them to work
+
+
 Driver Configuration
 --------------------
 


### PR DESCRIPTION
Some clients had problems with the device permissions for PCI passthrough. This adds a note to set them up with a udev rule