### PR TITLE
F OpenNebula/one#6121: Added User tab documentation

### DIFF
--- a/source/intro_release_notes/release_notes/whats_new.rst
+++ b/source/intro_release_notes/release_notes/whats_new.rst
@@ -35,6 +35,7 @@ Ruby Sunstone
 FireEdge Sunstone
 ================================================================================
 - Implemented VDCs tab in :ref:`FireEdge Sunstone <fireedge_sunstone>`.
+- Implemented Users tab in :ref:`FireEdge Sunstone <fireedge_sunstone>`.
 
 OneFlow - Service Management
 ================================================================================

--- a/source/management_and_operations/end-user_web_interfaces/fireedge_sunstone.rst
+++ b/source/management_and_operations/end-user_web_interfaces/fireedge_sunstone.rst
@@ -71,6 +71,7 @@ System
 --------------------------------------------------------------------------------
 
 - **VDCs Tab**: Users can see all their VDCs, and can update, rename and view the resources associated with them, and more. Also, users can create a new VDC from this tab.
+- **Users Tab**: Admins can access all the  users defined in the OpenNebula instance, and perform managing operations such as updating, enabling/disabling, setting quotas, and more. Also, admins can create new Users from this tab.
 
 .. _fireedge_sunstone_settings_tab:
 
@@ -144,6 +145,7 @@ The views definitions are placed in the ``/etc/one/fireedge/sunstone/`` director
     |   |-- image-tab.yaml            <--- the Image tab configuration file
     |   |-- marketplace-app-tab.yaml  <--- the Marketplace App tab configuration file
     |   |-- sec-group-tab.yaml        <--- the Security Group tab configuration file
+    |   |-- user-tab.yaml             <--- the User tab configuration file
     |   |-- vdc-tab.yaml              <--- the VDC tab configuration file 
     |   |-- vm-tab.yaml               <--- the VM tab configuration file
     |   |-- vm-template-tab.yaml      <--- the VM Template tab configuration file


### PR DESCRIPTION
## Description

Adds the OpenNebula/one#6121 user's tab feature to the [whats new](https://github.com/OpenNebula/docs/blob/master/source/intro_release_notes/release_notes/whats_new.rst) and [web management and operations](https://github.com/OpenNebula/docs/blob/master/source/management_and_operations/end-user_web_interfaces/fireedge_sunstone.rst) sections.

---
### Applies to:
* **master**

#### Related to:
* OpenNebula/one#6121