### PR TITLE
B OpenNebula/One#6420: add ca-es keymap

### DIFF
--- a/source/intro_release_notes/release_notes_enterprise/resolved_issues_681.rst
+++ b/source/intro_release_notes/release_notes_enterprise/resolved_issues_681.rst
@@ -48,3 +48,4 @@ The following issues has been solved in 6.8.1:
 - `Fix vCenter nic_attach action throwing parsing error <https://github.com/OpenNebula/one/issues/6391>`__.
 - `Fix labeling system in FireEdge Sunstone <https://github.com/OpenNebula/one/issues/6362>`__.
 - `Fix Sunstone issues unnecessary call when creating a marketplace app <https://github.com/OpenNebula/one/issues/6334>`__.
+- `Fix missing catalan keymap <https://github.com/OpenNebula/one/issues/6420>`__.


### PR DESCRIPTION
This PR applies to:
 - one-6.8-maintenance