### PR TITLE
B OpenNebula/one#6431: add vcenter image issue to known issues

### DIFF
--- a/source/intro_release_notes/release_notes/known_issues.rst
+++ b/source/intro_release_notes/release_notes/known_issues.rst
@@ -42,7 +42,8 @@ OpenNebula uses the ``cirrus`` graphical adapter for KVM Virtual Machines by def
 vCenter Snapshot behavior
 =================================
 
-VMs in vCenter 7.0 exhibit a new behavior regarding snapshots and disks attach/detach operations. When vCenter 7.0 detects any change in the number of disks attached to a VM, it automatically cleans all the VM snapshots. OpenNebula doesn't take this into account yet, so the snapshots stated by OpenNebula, after a disk attach or disk detach, are pointing to a null vCenter reference, and as such, cannot be used. Please keep this in mind before a solution is implemented.
+- VMs in vCenter 7.0 exhibit a new behavior regarding snapshots and disks attach/detach operations. When vCenter 7.0 detects any change in the number of disks attached to a VM, it automatically cleans all the VM snapshots. OpenNebula doesn't take this into account yet, so the snapshots stated by OpenNebula, after a disk attach or disk detach, are pointing to a null vCenter reference, and as such, cannot be used. Please keep this in mind before a solution is implemented.
+- In both vCenter 7.0 and vCenter 8.0 when trying to create a vcenter datastore image with a URL for the source Path, a Timeout error is shown instead of the image ID. The Image is still created, but the output value from oneimage is incorrect.
 
 Warning when Exporting an App from the Marketplace Using CLI
 ================================================================================


### PR DESCRIPTION
### Description

Adds the vcenter image creation timeout issue to the known isuses for 6.8.1

### Branches to which this PR applies

- [ ] one-6.8-maintenance
