### PR TITLE
Add instructions to create RBD pool

### DIFF
--- a/source/open_cluster_deployment/storage_setup/ceph_ds.rst
+++ b/source/open_cluster_deployment/storage_setup/ceph_ds.rst
@@ -18,7 +18,8 @@ This guide assumes that you already have a functional Ceph Cluster in place. Add
 .. prompt:: bash $ auto
 
     $ ceph osd pool create one 128
-
+    $ ceph osd pool application enable one rbd
+    $ rbd pool init -p one
     $ ceph osd lspools
     0 data,1 metadata,2 rbd,6 one,
 


### PR DESCRIPTION
Add instructions to create RBD pool

### Description

Add instructions to create RBD pool. Without this step, adding RBD pools to Sunstone using `onedatastore create systemds.txt` will lead to zero space capacity in "Datastore menu"

### Branches to which this PR applies

- [x] master

<hr>

- [ ] Check this if this PR should **not** be squashed
