### PR TITLE
B OpenNebula/one#6453: Add Fix DB migration to 6.8.0 fails to Resolve…

### DIFF
--- a/source/intro_release_notes/release_notes_enterprise/resolved_issues_682.rst
+++ b/source/intro_release_notes/release_notes_enterprise/resolved_issues_682.rst
@@ -18,5 +18,5 @@ The following issues has been solved in 6.8.2:
 - `Fix [FSunstone] multiple issues with image pool view <https://github.com/OpenNebula/one/issues/6380>`__.
 - `Fix VMs with serveral SATA disks <https://github.com/OpenNebula/one/issues/5705>`__.
 - `Fix [Funstone] Fix validation checkbox <https://github.com/OpenNebula/one/issues/6418>`__.
-- `Fix  DB migration to 6.8.0 fails due to undefined method `text' <https://github.com/OpenNebula/one/issues/6453>`__.
+- `Fix  DB migration to 6.8.0 fails due to undefined method 'text' <https://github.com/OpenNebula/one/issues/6453>`__.
 

--- a/source/intro_release_notes/release_notes_enterprise/resolved_issues_682.rst
+++ b/source/intro_release_notes/release_notes_enterprise/resolved_issues_682.rst
@@ -18,4 +18,5 @@ The following issues has been solved in 6.8.2:
 - `Fix [FSunstone] multiple issues with image pool view <https://github.com/OpenNebula/one/issues/6380>`__.
 - `Fix VMs with serveral SATA disks <https://github.com/OpenNebula/one/issues/5705>`__.
 - `Fix [Funstone] Fix validation checkbox <https://github.com/OpenNebula/one/issues/6418>`__.
+- `Fix  DB migration to 6.8.0 fails due to undefined method `text' <https://github.com/OpenNebula/one/issues/6453>`__.
 


### PR DESCRIPTION
### Description
Add Fix DB migration to 6.8.0 fails due to undefined method `text'  to Resolved issues

### Branches to which this PR applies

<!--- Please check you didn't forget a branch this needs to be cherry picked to. --->
- [X] one-6.8-maintenance

<hr>

- [ ] Check this if this PR should **not** be squashed
