### PR TITLE
M #-: Fix for echo command to add LUKS key properly

### DIFF
--- a/source/management_and_operations/storage_management/images.rst
+++ b/source/management_and_operations/storage_management/images.rst
@@ -236,7 +236,7 @@ Then define the secret and set its value, beware it's base64 encoded. **This has
 
     $ virsh -c qemu:///system secret-define secret.xml
 
-    $ virsh -c qemu:///system secret-set-value a94c5c16-d936-4346-89ad-7067517f411a "$(echo secret-passphrase | base64)"
+    $ virsh -c qemu:///system secret-set-value a94c5c16-d936-4346-89ad-7067517f411a "$(echo -n secret-passphrase | base64)"
 
 Managing Images
 ================================================================================


### PR DESCRIPTION
### Description
'-n' option added to echo command when adding LUKS passkey to the libvirtd
### Branches to which this PR applies

<!--- Please check you didn't forget a branch this needs to be cherry picked to. --->

- [ ] master
- [ ] one-6.8
- [ ] one-6.8-maintenance
- [ ] one-6.4
- [ ] one-6.4-maintenance

<hr>

- [ ] Check this if this PR should **not** be squashed
