### PR TITLE
B OpenNebula/One#6450: Fix create vm button in clod view

### DIFF
--- a/source/intro_release_notes/release_notes_enterprise/resolved_issues_682.rst
+++ b/source/intro_release_notes/release_notes_enterprise/resolved_issues_682.rst
@@ -20,4 +20,4 @@ The following issues has been solved in 6.8.2:
 - `Fix [FSunstone] Fix validation checkbox <https://github.com/OpenNebula/one/issues/6418>`__.
 - `Fix DB migration to 6.8.0 fails due to undefined method 'text' <https://github.com/OpenNebula/one/issues/6453>`__.
 - `Fix [FSuntone] Implement Virtual Network Template Tab <https://github.com/OpenNebula/one/issues/6118>`__.
-
+- `Fix Create VM button is not fully disabled with setting "cloud_vm_create: false" <https://github.com/OpenNebula/one/issues/6450>`__.


### PR DESCRIPTION
### Description

This PR hides the create vms button when the cloud_vm_create option is set to false

### Branches to which this PR applies

- [x] one-6.8-maintenance
