### PR TITLE
B OpenNebula/One#6423: fix upload image in fireedge

### DIFF
--- a/source/intro_release_notes/release_notes_enterprise/resolved_issues_682.rst
+++ b/source/intro_release_notes/release_notes_enterprise/resolved_issues_682.rst
@@ -21,3 +21,4 @@ The following issues has been solved in 6.8.2:
 - `Fix DB migration to 6.8.0 fails due to undefined method 'text' <https://github.com/OpenNebula/one/issues/6453>`__.
 - `Fix [FSuntone] Implement Virtual Network Template Tab <https://github.com/OpenNebula/one/issues/6118>`__.
 - `Fix Create VM button is not fully disabled with setting "cloud_vm_create: false" <https://github.com/OpenNebula/one/issues/6450>`__.
+- `Fix [FSunstone] Cannot upload image <https://github.com/OpenNebula/one/issues/6423>`__.


### PR DESCRIPTION
### Description

this PR resolves the image upload with the directory set in the configuration file and when the request fails, it issues an error message blocking the image allocation request.

### Branches to which this PR applies

- [ ] one-6.8-maintenance

