### PR TITLE
B OpenNebula/one#6431: 'oneimage create timeout' resolved issues

### DIFF
--- a/source/intro_release_notes/release_notes_enterprise/resolved_issues_682.rst
+++ b/source/intro_release_notes/release_notes_enterprise/resolved_issues_682.rst
@@ -22,3 +22,4 @@ The following issues has been solved in 6.8.2:
 - `Fix [FSuntone] Implement Virtual Network Template Tab <https://github.com/OpenNebula/one/issues/6118>`__.
 - `Fix Create VM button is not fully disabled with setting "cloud_vm_create: false" <https://github.com/OpenNebula/one/issues/6450>`__.
 - `Fix [FSunstone] Cannot upload image <https://github.com/OpenNebula/one/issues/6423>`__.
+- `Fix timeout during oneimage create with higher curl versions <https://github.com/OpenNebula/one/issues/6431>`__.


### PR DESCRIPTION
### Description

Adding fix for timeout during `oneimage create` with high curl versions to resolved issues

### Branches to which this PR applies

<!--- Please check you didn't forget a branch this needs to be cherry picked to. --->

- [x] one-6.8-maintenance
