### PR TITLE
B Opennebula/one#6379 Fix VM Migration Failure Using Two SYSTEM_DS on same host

### DIFF
--- a/source/intro_release_notes/release_notes_enterprise/resolved_issues_682.rst
+++ b/source/intro_release_notes/release_notes_enterprise/resolved_issues_682.rst
@@ -13,6 +13,7 @@ The following new features have been backported to 6.8.2:
 
 The following issues has been solved in 6.8.2:
 
+- `Fix VM Migration Failure using two SYSTEM_DS on same host <https://github.com/OpenNebula/one/issues/6379>`
 - `Fix possible segfault in VM disk resize <https://github.com/OpenNebula/one/issues/6432>`__.
 - `Fix monitoring encryption <https://github.com/OpenNebula/one/issues/6445>`__.
 - `Fix accounting after resizing VM memory or CPU <https://github.com/OpenNebula/one/issues/6387>`__.


### PR DESCRIPTION
### Description

B Opennebula/one#6379 Fix VM Migration Failure Using Two SYSTEM_DS on same host

### Branches to which this PR applies

<!--- Please check you didn't forget a branch this needs to be cherry picked to. --->

- [ ] master
- [ ] one-6.8
- [ ] one-6.8-maintenance

<hr>

- [ ] Check this if this PR should **not** be squashed
