### PR TITLE
B #OpenNebula/6428: Replace deprecated apt-key

### DIFF
--- a/source/installation_and_configuration/frontend_installation/opennebula_repository_configuration.rst
+++ b/source/installation_and_configuration/frontend_installation/opennebula_repository_configuration.rst
@@ -74,13 +74,8 @@ First, add the repository signing GPG key on the Front-end by executing as user 
 
 .. prompt:: bash # auto
 
-    # wget -q -O- https://downloads.opennebula.io/repo/repo2.key | apt-key add -
+    # wget -q -O- https://downloads.opennebula.io/repo/repo2.key | gpg --dearmor --yes --output /usr/share/keyrings/opennebula.key
 
-.. important:: If you are using Ubuntu 22.04, ``apt-key`` to add signing GPG keys is about to be deprecated. Execute the following:
-
-    .. prompt:: bash # auto
-
-       # wget -q -O- https://downloads.opennebula.io/repo/repo2.key | gpg --dearmor --yes --output /etc/apt/trusted.gpg.d/opennebula.gpg
 
 and then continue with repository configuration:
 
@@ -89,7 +84,7 @@ and then continue with repository configuration:
 .. prompt:: bash # auto
    :substitutions:
 
-    # echo "deb https://<token>@enterprise.opennebula.io/repo/|version|/Debian/10 stable opennebula" > /etc/apt/sources.list.d/opennebula.list
+    # echo "deb [singed-by=/usr/share/keyrings/opennebula.key] https://<token>@enterprise.opennebula.io/repo/|version|/Debian/10 stable opennebula" > /etc/apt/sources.list.d/opennebula.list
     # apt-get update
 
 **Debian 11**
@@ -97,7 +92,7 @@ and then continue with repository configuration:
 .. prompt:: bash # auto
    :substitutions:
 
-    # echo "deb https://<token>@enterprise.opennebula.io/repo/|version|/Debian/11 stable opennebula" > /etc/apt/sources.list.d/opennebula.list
+    # echo "deb [singed-by=/usr/share/keyrings/opennebula.key] https://<token>@enterprise.opennebula.io/repo/|version|/Debian/11 stable opennebula" > /etc/apt/sources.list.d/opennebula.list
     # apt-get update
 
 **Ubuntu 20.04**
@@ -105,7 +100,7 @@ and then continue with repository configuration:
 .. prompt:: bash # auto
    :substitutions:
 
-    # echo "deb https://<token>@enterprise.opennebula.io/repo/|version|/Ubuntu/20.04 stable opennebula" > /etc/apt/sources.list.d/opennebula.list
+    # echo "deb [singed-by=/usr/share/keyrings/opennebula.key] https://<token>@enterprise.opennebula.io/repo/|version|/Ubuntu/20.04 stable opennebula" > /etc/apt/sources.list.d/opennebula.list
     # apt-get update
 
 **Ubuntu 22.04**
@@ -113,7 +108,7 @@ and then continue with repository configuration:
 .. prompt:: bash # auto
    :substitutions:
 
-    # echo "deb https://<token>@enterprise.opennebula.io/repo/|version|/Ubuntu/22.04 stable opennebula" > /etc/apt/sources.list.d/opennebula.list
+    # echo "deb [singed-by=/usr/share/keyrings/opennebula.key] https://<token>@enterprise.opennebula.io/repo/|version|/Ubuntu/22.04 stable opennebula" > /etc/apt/sources.list.d/opennebula.list
     # apt-get update
 
 .. note::
@@ -122,7 +117,7 @@ and then continue with repository configuration:
 
     .. prompt:: bash # auto
 
-       # echo "deb https://<token>@enterprise.opennebula.io/repo/6.6.1/Ubuntu/22.04 stable opennebula" > /etc/apt/sources.list.d/opennebula.list
+       # echo "deb [singed-by=/usr/share/keyrings/opennebula.key] https://<token>@enterprise.opennebula.io/repo/6.6.1/Ubuntu/22.04 stable opennebula" > /etc/apt/sources.list.d/opennebula.list
        # apt-get update
 
 In Debian and Ubuntu it's possible (and recommended) to store a customer token in a separate file to the repository configuration. If you choose to store the repository credentials separately, you need to avoid using the ``<token>@`` part in the repository definitions above. You should create a new file ``/etc/apt/auth.conf.d/opennebula.conf`` with the following structure and replace the ``<user>`` and ``<password>`` parts with the customer credentials you have received:
@@ -194,14 +189,14 @@ First, add the repository signing GPG key on the Front-end by executing as user 
 
 .. prompt:: bash # auto
 
-    # wget -q -O- https://downloads.opennebula.io/repo/repo2.key | apt-key add -
+    # wget -q -O- https://downloads.opennebula.io/repo/repo2.key | gpg --dearmor --yes --output /usr/share/keyrings/opennebula.key
 
 **Debian 10**
 
 .. prompt:: bash # auto
    :substitutions:
 
-    # echo "deb https://downloads.opennebula.io/repo/|version|/Debian/10 stable opennebula" > /etc/apt/sources.list.d/opennebula.list
+    # echo "deb [singed-by=/usr/share/keyrings/opennebula.key] https://downloads.opennebula.io/repo/|version|/Debian/10 stable opennebula" > /etc/apt/sources.list.d/opennebula.list
     # apt-get update
 
 **Debian 11**
@@ -209,7 +204,7 @@ First, add the repository signing GPG key on the Front-end by executing as user 
 .. prompt:: bash # auto
    :substitutions:
 
-    # echo "deb https://downloads.opennebula.io/repo/|version|/Debian/11 stable opennebula" > /etc/apt/sources.list.d/opennebula.list
+    # echo "deb [singed-by=/usr/share/keyrings/opennebula.key] https://downloads.opennebula.io/repo/|version|/Debian/11 stable opennebula" > /etc/apt/sources.list.d/opennebula.list
     # apt-get update
 
 **Ubuntu 20.04**
@@ -217,7 +212,7 @@ First, add the repository signing GPG key on the Front-end by executing as user 
 .. prompt:: bash # auto
    :substitutions:
 
-    # echo "deb https://downloads.opennebula.io/repo/|version|/Ubuntu/20.04 stable opennebula" > /etc/apt/sources.list.d/opennebula.list
+    # echo "deb [singed-by=/usr/share/keyrings/opennebula.key] https://downloads.opennebula.io/repo/|version|/Ubuntu/20.04 stable opennebula" > /etc/apt/sources.list.d/opennebula.list
     # apt-get update
 
 **Ubuntu 22.04**
@@ -225,5 +220,5 @@ First, add the repository signing GPG key on the Front-end by executing as user 
 .. prompt:: bash # auto
    :substitutions:
 
-    # echo "deb https://downloads.opennebula.io/repo/|version|/Ubuntu/22.04 stable opennebula" > /etc/apt/sources.list.d/opennebula.list
+    # echo "deb [singed-by=/usr/share/keyrings/opennebula.key] https://downloads.opennebula.io/repo/|version|/Ubuntu/22.04 stable opennebula" > /etc/apt/sources.list.d/opennebula.list
     # apt-get update


### PR DESCRIPTION
### Description

- apt-key is warned to be deprecated after Ubuntu 2204
- it's a good practice not to add apt keys inside fully trusted /etc/apt/trusted path but rather /usr/share/keyrings and reffer them per apt repo

### Branches to which this PR applies
- [ ] master
