### PR TITLE
B OpenNebula/One#6229: fix sorting user inputs

### DIFF
--- a/source/intro_release_notes/release_notes/whats_new.rst
+++ b/source/intro_release_notes/release_notes/whats_new.rst
@@ -42,3 +42,4 @@ Other Issues Solved
 ================================================================================
 - `Fix for systemd unit files in the part responsible for log compression <https://github.com/OpenNebula/one/issues/6282>`__.
 - `Fix [FSunstone] multiple issues with image pool view <https://github.com/OpenNebula/one/issues/6380>`__.
+- `Fix [FSunstone] User Input list sorting error <https://github.com/OpenNebula/one/issues/6229>`__.


### PR DESCRIPTION
### Description

This PR fixes the display of the MEMORY, CPU and VCPU inputs in the VM instantiate form and fixes the order of the options when they are numbers

### Branches to which this PR applies

- [ ] master

