### PR TITLE
B OpenNebula/One#6229: fix sort options in user_inputs

### DIFF
--- a/source/intro_release_notes/release_notes_enterprise/resolved_issues_682.rst
+++ b/source/intro_release_notes/release_notes_enterprise/resolved_issues_682.rst
@@ -25,3 +25,4 @@ The following issues has been solved in 6.8.2:
 - `Fix Create VM button is not fully disabled with setting "cloud_vm_create: false" <https://github.com/OpenNebula/one/issues/6450>`__.
 - `Fix [FSunstone] Cannot upload image <https://github.com/OpenNebula/one/issues/6423>`__.
 - `Fix timeout during oneimage create with higher curl versions <https://github.com/OpenNebula/one/issues/6431>`__.
+- `Fix [FSunstone] User Input list sorting error <https://github.com/OpenNebula/one/issues/6229>`__.


### PR DESCRIPTION
### Description

This PR fixes the display of the MEMORY, CPU and VCPU inputs in the VM instantiate form and fixes the order of the options when they are numbers

### Branches to which this PR applies

- [ ] one-6.8-maintenance
