### PR TITLE
B OpenNebula/One#6219: add generic template settings

### DIFF
--- a/source/intro_release_notes/release_notes_enterprise/resolved_issues_682.rst
+++ b/source/intro_release_notes/release_notes_enterprise/resolved_issues_682.rst
@@ -33,3 +33,4 @@ Also, the following issues have been solved in the FireEdge Sunstone Web UI:
 - `Fix User Input list sorting error <https://github.com/OpenNebula/one/issues/6229>`__.
 - `Fix poweroff hard available for SHUTDOWN state <https://github.com/OpenNebula/one/issues/6448>`__.
 - `New Virtual Network Template Tab <https://github.com/OpenNebula/one/issues/6118>`__.
+- `Add generic template to Settings for User template <https://github.com/OpenNebula/one/issues/6219>`__.


### PR DESCRIPTION
### Description

This PR adds user settings in the "Setting" tab, adjusts the where some fireedge settings are saved in the user template, copy to clipboard functionality

### Branches to which this PR applies

<!--- Please check you didn't forget a branch this needs to be cherry picked to. --->

- [x] one-6.8-maintenance

<hr>

- [ ] Check this if this PR should **not** be squashed
