### PR TITLE
F OpenNebula/one#5687: Update config download link

### DIFF
--- a/source/installation_and_configuration/opennebula_services/fireedge.rst
+++ b/source/installation_and_configuration/opennebula_services/fireedge.rst
@@ -28,7 +28,7 @@ Main Features
 .. _fireedge_files_note:
 .. note::
 
-    We are continually expanding the feature set of FireEdge Sunstone, and hence its configuration files are in constant change. In versions 6.8.2 and later, configuration files in ``/etc/one/fireedge/sunstone/`` can be replaced by the ones that can be downloaded `here <https://bit.ly/one-681-config>`__ in order to activate the latest features.
+    We are continually expanding the feature set of FireEdge Sunstone, and hence its configuration files are in constant change. In versions 6.8.2 and later, configuration files in ``/etc/one/fireedge/sunstone/`` can be replaced by the ones that can be downloaded `here <https://bit.ly/fe-682-config>`__ in order to activate the latest features.
 
 
 

--- a/source/intro_release_notes/release_notes_enterprise/resolved_issues_682.rst
+++ b/source/intro_release_notes/release_notes_enterprise/resolved_issues_682.rst
@@ -11,9 +11,12 @@ The following new features have been backported to 6.8.2:
 - Virtual Routers now support ``FLOATING_ONLY`` attributes for their network NICs. When this attribute is set to ``yes`` no additional IPs are allocated for the VMs of the VR, :ref:`see more information on the Virtual Router guide <vrouter>`.
 - For VMs with resched flag add ``HOST_ID`` to :ref:`External Scheduler API <external_scheduler>`.
 - New operation to :ref:`attach/detach PCI passthrough devices in poweroff and undeployed <vm_guide2_pci>`. Note that this feature is available through the API and CLI in this 6.8.2 release.
-- Added the Cluster tab to Fireedge Sunstone. See :ref:`the Cluster guide <cluster_guide>` for more information.  To download configuration files, see :ref:`Configuration files <fireedge_files_note>`
-- Added the ACL tab to Fireedge Sunstone. See :ref:`the ACL guide <manage_acl>` for more information. To download configuration files, see :ref:`Configuration files <fireedge_files_note>`.
+- Added the Cluster tab to Fireedge Sunstone. See :ref:`the Cluster guide <cluster_guide>` for more information.
+- Added the ACL tab to Fireedge Sunstone. See :ref:`the ACL guide <manage_acl>` for more information.
 - Supported custom attributes at :ref:`Python binding <python>`.
+
+.. note::
+   In order to use the new functionality introduced in Fireedge sunstone, please refer to the following :ref:`guide <fireedge_files_note>`.
 
 The following issues have been solved in 6.8.2:
 


### PR DESCRIPTION
### Description

Update 6.8.2 config download link for FireEdge + change from [DownGit](https://minhaskamal.github.io/DownGit/#/home) to [download-directory](https://download-directory.github.io/) instead. Because for some reason, DownGit sometimes gets flagged as malicious.

### Branches to which this PR applies

<!--- Please check you didn't forget a branch this needs to be cherry picked to. --->

- [x] one-6.8-maintenance

<hr>

- [ ] Check this if this PR should **not** be squashed
