### PR TITLE
M #-: Fix wrong link in Resolved issues

### DIFF
--- a/source/intro_release_notes/release_notes_enterprise/resolved_issues_682.rst
+++ b/source/intro_release_notes/release_notes_enterprise/resolved_issues_682.rst
@@ -31,7 +31,7 @@ The following issues have been solved in 6.8.2:
 - `Fix timeout during oneimage create with higher curl versions <https://github.com/OpenNebula/one/issues/6431>`__.
 - `Fix occasional duplicate floating IP in HA environment, which cause monitroing issues <https://github.com/OpenNebula/one/issues/6372>`__.
 - `Fix oneflow client adding uri prefix path to the http request path <https://github.com/OpenNebula/one/issues/5768>`__.
-- `Fix PCI passthrough device addresses for machine models based on q35 <https://github.com/OpenNebula/one/issues/6372>`__.
+- `Fix PCI passthrough device addresses for machine models based on q35 <https://github.com/OpenNebula/one/issues/6492>`__.
 - `Fix updateconf API call to return an error when backup mode cannot be changed <https://github.com/OpenNebula/one/issues/6400>`__.
 - `Fix IP and MAC spoofing rules for Open vSwitch driver when using NIC alias <https://github.com/OpenNebula/one/issues/6483>`__.
 


### PR DESCRIPTION
### Description
Fix wrong link for "Fix PCI passthrough device addresses for machine models based on q35" in Resolved issues

### Branches to which this PR applies

<!--- Please check you didn't forget a branch this needs to be cherry picked to. --->

- [x] one-6.8
