### PR TITLE
M #-: Add fireedge=yes to scons command

### DIFF
--- a/source/integration_and_development/references/compile.rst
+++ b/source/integration_and_development/references/compile.rst
@@ -144,7 +144,7 @@ The packages do a ``system-wide`` installation. To create a similar environment,
     oneadmin@frontend:~/ $> wget <opennebula tar gz>
     oneadmin@frontend:~/ $> tar xzf <opennebula tar gz>
     oneadmin@frontend:~/ $> cd opennebula-x.y.z
-    oneadmin@frontend:~/opennebula-x.y.z/ $> scons -j2 mysql=yes syslog=yes
+    oneadmin@frontend:~/opennebula-x.y.z/ $> scons -j2 mysql=yes syslog=yes fireedge=yes
     [ lots of compiling information ]
     scons: done building targets.
     oneadmin@frontend:~/opennebula-x.y.z $> sudo ./install.sh -u oneadmin -g oneadmin


### PR DESCRIPTION
### Description
If a set of commands is executed as it is listed now in the [guide](https://docs.opennebula.io/6.8/integration_and_development/references/compile.html#) i.e.

```
oneadmin@frontend:~/ $> wget <opennebula tar gz>
oneadmin@frontend:~/ $> tar xzf <opennebula tar gz>
oneadmin@frontend:~/ $> cd opennebula-x.y.z
oneadmin@frontend:~/opennebula-x.y.z/ $> scons -j2 mysql=yes syslog=yes
[ lots of compiling information ]
scons: done building targets.
oneadmin@frontend:~/opennebula-x.y.z $> sudo ./install.sh -u oneadmin -g oneadmin
```

the following error appears:
```
cp: cannot stat '/home/pablo/Documents/OpenNebula/opennebula-6.8.0/src/fireedge/dist': No such file or directory
cp: cannot stat '/home/pablo/Documents/OpenNebula/opennebula-6.8.0/src/fireedge/node_modules': No such file or directory
```
In order to overcome that one needs to pass either ``fireedge=yes`` to scons command (what is added in that PR) or to add ``-c`` flag when invoking ./install.sh script, e.g.
```
sudo ./install.sh -u oneadmin -g oneadmin -c
```
### Branches to which this PR applies

<!--- Please check you didn't forget a branch this needs to be cherry picked to. --->

- [ ] master
- [ ] one-6.8
- [ ] one-6.8-maintenance