### PR TITLE
B #6509: Fix error reporting of CLI tools for JSON and YAML output

### DIFF
--- a/source/intro_release_notes/release_notes_enterprise/resolved_issues_683.rst
+++ b/source/intro_release_notes/release_notes_enterprise/resolved_issues_683.rst
@@ -19,6 +19,7 @@ The following issues have been solved in 6.8.3:
 - `Fix quota after VM disk (de)attach for CEPH, LVM datastores <https://github.com/OpenNebula/one/issues/6506>`__.
 - `Add QS Reference to README.md <https://github.com/OpenNebula/one/issues/6513>`__.
 - `Fix incorrect filtering of remove_off_hosts <https://github.com/OpenNebula/one/issues/6472>`__.
+- `Fix error reporting of CLI tools for JSON and YAML output <https://github.com/OpenNebula/one/issues/6509>`__.
 
 Also, the following issues have been solved in the FireEdge Sunstone Web UI:
 


### PR DESCRIPTION
### Description

New bug fix added to the list of resovled issues. The exit code of the CLI tools now is coherent when using the --json and --yaml options. 

### Branches to which this PR applies

<!--- Please check you didn't forget a branch this needs to be cherry picked to. --->

- [x] one-6.8-maintenance

<hr>

- [ ] Check this if this PR should **not** be squashed
