### PR TITLE
B OpenNebula/one#6509: Fix error reporting of CLI tools for JSON and YAML output

### DIFF
--- a/source/intro_release_notes/release_notes_enterprise/resolved_issues_646.rst
+++ b/source/intro_release_notes/release_notes_enterprise/resolved_issues_646.rst
@@ -17,3 +17,4 @@ The following issues has been solved in 6.4.6:
 - `Fix oneflow client adding uri prefix path to the http request path <https://github.com/OpenNebula/one/issues/5768>`__.
 - `Fix quota after VM disk (de)attach for CEPH, LVM datastores <https://github.com/OpenNebula/one/issues/6506>`__.
 - `Fix incorrect filtering of remove_off_hosts <https://github.com/OpenNebula/one/issues/6472>`__.
+- `Fix error reporting of CLI tools for JSON and YAML output <https://github.com/OpenNebula/one/issues/6509>`__.


### PR DESCRIPTION
### Description

New bug fix added to the list of resovled issues. The exit code of the CLI tools now is coherent when using the --json and --yaml options. 

### Branches to which this PR applies

<!--- Please check you didn't forget a branch this needs to be cherry picked to. --->

- [x] one-6.4-maintenance

<hr>

- [ ] Check this if this PR should **not** be squashed