### PR TITLE
Added resolved issue #6511 to 6.4.6 release notes.

### DIFF
--- a/source/intro_release_notes/release_notes_enterprise/resolved_issues_646.rst
+++ b/source/intro_release_notes/release_notes_enterprise/resolved_issues_646.rst
@@ -18,3 +18,4 @@ The following issues has been solved in 6.4.6:
 - `Fix quota after VM disk (de)attach for CEPH, LVM datastores <https://github.com/OpenNebula/one/issues/6506>`__.
 - `Fix incorrect filtering of remove_off_hosts <https://github.com/OpenNebula/one/issues/6472>`__.
 - `Fix error reporting of CLI tools for JSON and YAML output <https://github.com/OpenNebula/one/issues/6509>`__.
+- `Fix CLI listing formatting ignored when passing --search <https://github.com/OpenNebula/one/issues/6511>`__.


### PR DESCRIPTION
### Description

This pull request updates the 6.4.6 release notes to include the resolution of issue #6511, which fixes the CLI listing formatting when using the --search option.

### Branches to which this PR applies

- [x] one-6.4-maintenance

<hr>

- [ ] Check this if this PR should **not** be squashed
