### PR TITLE
 B OpenNebula/one#6476: READY attribute wasn't removed for terminated VMs

### DIFF
--- a/source/intro_release_notes/release_notes_enterprise/resolved_issues_684.rst
+++ b/source/intro_release_notes/release_notes_enterprise/resolved_issues_684.rst
@@ -11,4 +11,5 @@ The following new features have been backported to 6.8.4:
 
 
 The following issues have been solved in 6.8.4:
-- `Fix READY attribute wasn't remove terminated VMs <https://github.com/OpenNebula/one/issues/6476>`__.
+
+- `Fix READY attribute wasn't removed for terminated VMs <https://github.com/OpenNebula/one/issues/6476>`__.

--- a/source/intro_release_notes/release_notes_enterprise/resolved_issues_684.rst
+++ b/source/intro_release_notes/release_notes_enterprise/resolved_issues_684.rst
@@ -11,3 +11,4 @@ The following new features have been backported to 6.8.4:
 
 
 The following issues have been solved in 6.8.4:
+- `Fix READY attribute wasn't remove terminated VMs <https://github.com/OpenNebula/one/issues/6476>`__.


### PR DESCRIPTION
### Description

<!--- Please leave a helpful description of the PR here. --->

### Branches to which this PR applies

<!--- Please check you didn't forget a branch this needs to be cherry picked to. --->

- [x] one-6.8-maintenance

<hr>

- [ ] Check this if this PR should **not** be squashed
