### PR TITLE
M #-: Add word to spellchecking wordlist

### DIFF
--- a/source/ext/spellchecking/wordlists/opennebula.txt
+++ b/source/ext/spellchecking/wordlists/opennebula.txt
@@ -676,6 +676,7 @@ topologies
 tunables
 tx
 txt
+ubuntu
 udev
 uid
 umask


### PR DESCRIPTION
### Description

Added "ubuntu" in lowercase to the wordlist since it was causing the spell check to fail, and the word in lowercase will probably pop up again in other docs, in the Version string of packages e.g. 8.0.28-0ubuntu4

### Branches to which this PR applies

<!--- Please check you didn't forget a branch this needs to be cherry picked to. --->

- [ ] master

<hr>

- [ ] Check this if this PR should **not** be squashed
