### PR TITLE
M #-: change the path to "logos" directory in Fireedge

### DIFF
--- a/source/installation_and_configuration/opennebula_services/fireedge.rst
+++ b/source/installation_and_configuration/opennebula_services/fireedge.rst
@@ -180,7 +180,7 @@ You can add your logo to the login, main, favicon and loading screens by updatin
 - The logo configuration is done in the ``/etc/one/fireedge/sunstone/sunstone-views.yaml`` file.
 - The logo of the main UI screen is defined for each view.
 
-The logo image must be copied to ``/usr/lib/one/fireedge/src/client/assets/images/logos``.
+The logo image must be copied to ``/usr/lib/one/fireedge/dist/client/assets/images/logos``.
 
 The following example shows how you can change the logo to a generic linux one (included by default in all FireEdge installations):
 


### PR DESCRIPTION
### Description

<!--- Please leave a helpful description of the PR here. --->

According to my test with Fireedge - it looks for a custom logo in the `/usr/lib/one/fireedge/dist/client/assets/images/logos/` direcotry instead of the one mentioned in docs. 

### Branches to which this PR applies

<!--- Please check you didn't forget a branch this needs to be cherry picked to. --->

- [X] master
- [X] one-6.10

<hr>

- [ ] Check this if this PR should **not** be squashed
