### PR TITLE
M #-: OneKE/QS: Use correct apiVersion for IngressRoute (fix)

### DIFF
--- a/source/quick_start/usage_basics/running_kubernetes_clusters.rst
+++ b/source/quick_start/usage_basics/running_kubernetes_clusters.rst
@@ -361,7 +361,8 @@ On the Kubernetes master node, create a file called ``expose-nginx.yaml`` with t
           port: 80
           targetPort: 80
     ---
-    apiVersion: traefik.containo.us/v1alpha1
+    # In Traefik < 3.0.0 it used to be "apiVersion: traefik.containo.us/v1alpha1".
+    apiVersion: traefik.io/v1alpha1
     kind: IngressRoute
     metadata:
       name: nginx


### PR DESCRIPTION
### Description

Traefik >= 3 expects `apiVersion: traefik.io/v1alpha1`, this PR fixes the example in OneKE/QS.

### Branches to which this PR applies

<!--- Please check you didn't forget a branch this needs to be cherry picked to. --->

- [x] master
- [ ] one-X.X
- [ ] one-X.X-maintenance

<hr>

- [ ] Check this if this PR should **not** be squashed
