### PR TITLE
M #: Add required extra repo for rhel family

### DIFF
--- a/source/installation_and_configuration/frontend_installation/opennebula_repository_configuration.rst
+++ b/source/installation_and_configuration/frontend_installation/opennebula_repository_configuration.rst
@@ -23,6 +23,14 @@ OpenNebula Systems provides an OpenNebula Enterprise Edition to customers with a
 AlmaLinux/RHEL
 --------------------------------------------------------------------------------
 
+In **rhel9** and **AlmaLinux9** Some dependencies cannot be found in the default repositories. Some extra repositories need to be enabled. To do this, execute the following as the root user:
+
+.. code-block:: bash
+
+    repo=$(yum repolist --disabled | grep -i -e powertools -e crb | awk '{print $1}' | head -1)
+    yum config-manager --set-enabled $repo && yum makecache
+
+
 To add the OpenNebula enterprise repository, execute the following as user ``root``:
 
 **RHEL 8, 9**
@@ -137,6 +145,14 @@ The community edition of OpenNebula offers the full functionality of the Cloud M
 
 AlmaLinux/RHEL
 --------------------------------------------------------------------------------
+
+In **rhel9** and **AlmaLinux9** Some dependencies cannot be found in the default repositories. Some extra repositories need to be enabled. To do this, execute the following as the root user:
+
+.. code-block:: bash
+
+    repo=$(yum repolist --disabled | grep -i -e powertools -e crb | awk '{print $1}' | head -1)
+    yum config-manager --set-enabled $repo && yum makecache
+
 
 To add OpenNebula repository, execute the following as user ``root``:
 


### PR DESCRIPTION
### Description

If CRB/powertools is [not enabled](https://github.com/OpenNebula/one-infra/blob/bde4928d80caed984bb422877e850ba7c934888f/microenvs/ansible/roles/opennebula-repository-microenv/tasks/RedHat.yml#L87-L96) then installing opennebula is not possible on rhel variants

```
[root@alma9-247 ~]# yum install opennebula
Last metadata expiration check: 0:00:05 ago on Fri Sep 13 17:22:16 2024.
Error:
 Problem: conflicting requests
  - nothing provides libmysqlclient.so.21()(64bit) needed by opennebula-6.10.0-1.el9.x86_64 from opennebula
  - nothing provides libmysqlclient.so.21(libmysqlclient_21.0)(64bit) needed by opennebula-6.10.0-1.el9.x86_64 from opennebula
(try to add '--skip-broken' to skip uninstallable packages or '--nobest' to use not only best candidate packages)
```

### Branches to which this PR applies

<!--- Please check you didn't forget a branch this needs to be cherry picked to. --->

- [ ] master
- [ ] one-6.10
- [ ] one-6.10-maintenance

<hr>

- [ ] Check this if this PR should **not** be squashed
