### PR TITLE
M #~: removed fireedge without ssl

### DIFF
--- a/source/installation_and_configuration/opennebula_services/fireedge.rst
+++ b/source/installation_and_configuration/opennebula_services/fireedge.rst
@@ -166,10 +166,6 @@ Once the server is initialized, it creates the file ``/var/lib/one/.one/fireedge
 
 In HA environments, ``fireedge_key`` needs to be copied from the first leader to the followers. Optionally, in order to have the provision logs available in all the HA nodes, ``/var/lib/one/fireedge`` need to be shared between nodes.
 
-.. _fireedge_ssl_without_nginx:
-
-If you need to execute the FireEdge with SSL Certificate, in the following path: ``/usr/lib/one/fireedge`` you must create a folder called ``cert`` and inside it place the files ``cert.pem`` and ``key.pem``. After doing that you need to restart ``opennebula-fireedge``.
-
 .. _fireedge_configuration_for_sunstone:
 
 Tuning and Extending


### PR DESCRIPTION
### Description

Fireedge cannot have SSL unless it is through a proxy that is upstream!

### Branches to which this PR applies

<!--- Please check you didn't forget a branch this needs to be cherry picked to. --->

- [ ] master
- [ ] one-6.10-maintenance

<hr>

- [ ] Check this if this PR should **not** be squashed
