### PR TITLE
M #-: Fix copyright date in documentation footer

### DIFF
--- a/source/_templates/footer.html
+++ b/source/_templates/footer.html
@@ -3,5 +3,5 @@
 {% set show_copyright = False %}
 
 {% block extrafooter %}
-      Copyright 2002-2023 &copy; OpenNebula Project (OpenNebula.io). All Rights Reserved. Please send comments to the <a href="mailto:webmaster [at] opennebula [dot] io">webmaster</a>. <br/>Read the <a href="http://opennebula.io/legal">Legal Notice</a>. This site is hosted by <a href="http://opennebula.io">OpenNebula Systems</a>.
+      Copyright 2002-2024 &copy; OpenNebula Project (OpenNebula.io). All Rights Reserved. Please send comments to the <a href="mailto:webmaster [at] opennebula [dot] io">webmaster</a>. <br/>Read the <a href="http://opennebula.io/legal">Legal Notice</a>. This site is hosted by <a href="http://opennebula.io">OpenNebula Systems</a>.
 {% endblock %}


### PR DESCRIPTION
### Description

Updated the copyright year in the footer that appears on all docs pages

### Branches to which this PR applies

<!--- Please check you didn't forget a branch this needs to be cherry picked to. --->

- [ ] master
- [ ] one-6.10
- [ ] one-X.X-maintenance

<hr>

- [ ] Check this if this PR should **not** be squashed
