### PR TITLE
M #-: Add a note for Debian 11 repo

### DIFF
--- a/source/ext/spellchecking/wordlists/opennebula.txt
+++ b/source/ext/spellchecking/wordlists/opennebula.txt
@@ -91,9 +91,9 @@ Mountpoints
 Multicast
 Multicluster
 Multus
+NSX
 Netplan
 Nokogiri
-NSX
 Numa
 Onecfg
 Oneflow
@@ -412,6 +412,7 @@ kb
 keepalived
 keymap
 keyring
+keyrings
 keytab
 kubeconfig
 kubernetes

--- a/source/installation_and_configuration/frontend_installation/opennebula_repository_configuration.rst
+++ b/source/installation_and_configuration/frontend_installation/opennebula_repository_configuration.rst
@@ -80,6 +80,15 @@ Debian/Ubuntu
 
 First, add the repository signing GPG key on the Front-end by executing as user ``root``:
 
+.. note::
+
+    It might be needed to create /etc/apt/keyrings directory in Debian 11 because it does not exist by default:
+
+    .. prompt:: bash # auto
+
+        # mkdir -p /etc/apt/keyrings
+
+
 .. prompt:: bash # auto
 
     # wget -q -O- https://downloads.opennebula.io/repo/repo2.key | gpg --dearmor --yes --output /etc/apt/keyrings/opennebula.gpg


### PR DESCRIPTION
### Description
A command
```
wget -q -O- https://downloads.opennebula.io/repo/repo2.key | gpg --dearmor --yes --output /etc/apt/keyrings/opennebula.gpg
```
fails on a Debian 11 based hosts because a `/etc/apt/keyrings` directory does not exist by default. So one needs to create it first which is proposed the note about.


### Branches to which this PR applies

<!--- Please check you didn't forget a branch this needs to be cherry picked to. --->

- [x] master
- [ ] one-6.10
- [ ] one-6.10-maintenance

<hr>

- [ ] Check this if this PR should **not** be squashed
