### PR TITLE
Fix oneprovision command usage on provisioning_edge_cluster.rst

### DIFF
--- a/source/quick_start/operation_basics/provisioning_edge_cluster.rst
+++ b/source/quick_start/operation_basics/provisioning_edge_cluster.rst
@@ -224,7 +224,7 @@ First, log in to the Front-end node.
 
 .. tip:: If you installed the Front-end by following the :doc:`Quickstart with miniONE on AWS <../deployment_basics/try_opennebula_on_kvm>` tutorial, to log into the Front-end you will need to use the key stored in the PEM file that you obtained from AWS. For details, see :ref:`minione_log_in_to_ec2` in that tutorial.
 
-On the Front-end node, login as ``oneadmin`` user to perform the following actions:
+On the Front-end node, use the ``oneprovision`` command to perform the following actions:
 
 List clusters in the provision: ``oneprovision cluster list``.
 

--- a/source/quick_start/operation_basics/provisioning_edge_cluster.rst
+++ b/source/quick_start/operation_basics/provisioning_edge_cluster.rst
@@ -224,7 +224,7 @@ First, log in to the Front-end node.
 
 .. tip:: If you installed the Front-end by following the :doc:`Quickstart with miniONE on AWS <../deployment_basics/try_opennebula_on_kvm>` tutorial, to log into the Front-end you will need to use the key stored in the PEM file that you obtained from AWS. For details, see :ref:`minione_log_in_to_ec2` in that tutorial.
 
-On the Front-end node, use the ``oneadmin`` command to perform the following actions:
+On the Front-end node, login as ``oneadmin`` user to perform the following actions:
 
 List clusters in the provision: ``oneprovision cluster list``.
 


### PR DESCRIPTION
### Description

It looks that we refer here `oneadmin` as a command instead of as an user.

### Branches to which this PR applies

- [ ] one-6.10
- [ ] one-6.10-maintenance

<hr>

- [ ] Check this if this PR should **not** be squashed
