### PR TITLE
M #-: Add link to installing Front-end onprem

### DIFF
--- a/source/overview/cloud_architecture_and_design/cloud_architecture_design.rst
+++ b/source/overview/cloud_architecture_and_design/cloud_architecture_design.rst
@@ -8,7 +8,7 @@ This page describes the high-level steps to design and deploy an OpenNebula clou
 
 To familiarize yourself with deployment and daily operations, or if you want to quickly try an Edge, Hybrid or Multi-cloud deployment, we strongly recommend you begin with the :ref:`Quick Start Guide <quick_start>`. In the Quick Start, you can:
 
-  * :ref:`Install an OpenNebula Front-end <try_opennebula_on_kvm>`
+  * :ref:`Install an OpenNebula Front-end <deployment_basics_overview>`
   * Deploy on-demand :ref:`Edge Clusters <first_edge_cluster>` on remote cloud providers
   * Deploy :ref:`Virtual Machines <running_virtual_machines>` and :ref:`Kubernetes clusters <running_kubernetes_clusters>`
   

--- a/source/quick_start/deployment_basics/overview.rst
+++ b/source/quick_start/deployment_basics/overview.rst
@@ -16,6 +16,7 @@ Each section builds on the previous one, to take you from a bare install to quic
 
 First, to install your Front-end, please select your preferred infrastructure:
 
+- :ref:`Deploy OpenNebula Front-end On-prem <try_opennebula_onprem>`.
 - :ref:`Deploy OpenNebula Front-end on AWS <try_opennebula_on_kvm>`.
 - :ref:`Deploy OpenNebula Front-end on VMware <try_opennebula_on_vmware>`.
 - :ref:`Try OpenNebula Hosted Front-end  <try_opennebula_hosted>`.


### PR DESCRIPTION
### Description

In "Deployment Basics Overview", added link to Deploying a Front-end On-prem page.
In "Cloud Arch. and Design", modified a link to point to "Deployment Basics Overview" instead of "Deploying on AWS", so readers can see the different deployment possibilities.

### Branches to which this PR applies

- [ ] master
- [ ] one-6.10
- [ ] one-6.10-maintenance

<hr>

- [ ] Check this if this PR should **not** be squashed
