### PR TITLE
Clarify live migration limitation

### DIFF
--- a/source/management_and_operations/vm_management/vm_instances.rst
+++ b/source/management_and_operations/vm_management/vm_instances.rst
@@ -854,10 +854,10 @@ To explain that, we are gonna use an example:
   leases:
     terminate:
       edit: false
-      execute_after_weeks: 3      
+      execute_after_weeks: 3
     poweroff:
       edit: true
-      execute_after_minutes: 5      
+      execute_after_minutes: 5
 
 The previous example will create two schedule actions:
 
@@ -1017,7 +1017,7 @@ There are some ``onevm`` commands operations meant for the cloud administrators:
 **Deployment:**
 
 -  ``deploy``: Starts an existing VM in a specific Host.
--  ``migrate --live``: The Virtual Machine is transferred between Hosts with no noticeable downtime.
+-  ``migrate --live``: The Virtual Machine is transferred between Hosts with no noticeable downtime. The VM storage cannot be migrated to other system datastores.
 -  ``migrate``: The VM gets stopped and resumed in the target host. In an infrastructure with :ref:`multiple system datastores <sched_ds>`, the VM storage can be also migrated (the datastore id can be specified).
 
 Note: By default, the above operations do not check the target host capacity. You can use the ``--enforce`` option to be sure that the host capacity is not overcommitted.
@@ -1186,7 +1186,7 @@ After that you can access the VM and configure the SSH service:
 .. |sunstone_guac_rdp| image:: /images/sunstone_guac_rdp.png
 .. |sunstone_guac_rdp_interface| image:: /images/sunstone_guac_rdp_interface.png
 .. |sunstone_guac_nic_1| image:: /images/sunstone_guac_nic_1.png
-.. |sunstone_guac_nic_2| image:: /images/sunstone_guac_nic_2.png    
+.. |sunstone_guac_nic_2| image:: /images/sunstone_guac_nic_2.png
 .. |sunstone_sg_main_view| image:: /images/sunstone_sg_main_view.png
 .. |sunstone_sg_attach| image:: /images/sunstone_sg_attach.png
 .. |fireedge_sunstone_ssh_list| image:: /images/fireedge_sunstone_ssh_list.png


### PR DESCRIPTION
### Description

<!--- Please leave a helpful description of the PR here. --->

When using the [API](https://docs.opennebula.io/6.10/integration_and_development/system_interfaces/api.html#one-vm-migrate) or the CLI

```
onevm migrate --live --help
## USAGE
migrate <range|vmid_list> <hostid> [<datastoreid>]
        Migrates the given running VM to another Host. If used with --live
        parameter the miration is done without downtime.

        States: RUNNING
        valid options: enforce, live, poweroff, poweroff_hard

## OPTIONS
     -e, --enforce             Enforce that the host capacity is not exceeded
     --live                    Do the action with the VM running
     --poff                    Do the migrate by poweringoff the vm
     --poff-hard               Do the migrate by poweringoff hard the vm
     -v, --verbose             Verbose mode
     -h, --help                Show this message
     -V, --version             Show version and copyright information
     --user name               User name used to connect to OpenNebula
     --password password       Password to authenticate with OpenNebula
     --endpoint endpoint       URL of OpenNebula xmlrpc frontend
```

one might be under the impression that migrating system datastores live is possible. However, the API has a validation

```log
[one.vm.migrate] A migration to a different system datastore cannot be performed live.
```

Clarify this on the documentation.

Also I don't know why other changes appeared, probably some automatic linting happened on vscode.

### Branches to which this PR applies

<!--- Please check you didn't forget a branch this needs to be cherry picked to. --->

- [ ] master
- [ ] one-6.10
- [ ] one-6.10-maintenance

<hr>

- [ ] Check this if this PR should **not** be squashed
