### PR TITLE
Modify acks for 6.10

### DIFF
--- a/source/intro_release_notes/release_notes/acknowledgements.rst
+++ b/source/intro_release_notes/release_notes/acknowledgements.rst
@@ -8,6 +8,7 @@ The OpenNebula project would like to thank the `community members <https://githu
 
 Some of the new functionality in OpenNebula 6.10 has been made possible through funding from the following innovation projects:
 
+
    * `SovereignEdge.Cognit <http://cognit.sovereignedge.eu>`__ (Grant Agreement 101092711), through the European Union’s Horizon Europe Research and Innovation Programme.
-   * `ONEedge5G <http://oneedge5g.eu>`__ (Grant Agreement TSI-064200-2023-1), supported by Ministerio para la Transformación Digital y de la Función Pública through the UNICO I+D 6G Program, co-funded by the European Union – NextGenerationEU through the Recovery and Resilience Facility (RRF).
-   * `ONEnextGen <http://onenextgen.eu>`__ (Grant Agreement UNICO IPCEI-2023-003), supported by Ministerio para la Transformación Digital y de la Función Pública through the UNICO IPCEI Program, co-funded by the European Union – NextGenerationEU through the Recovery and Resilience Facility (RRF).
+   * `ONEedge5G <http://oneedge5g.eu>`__ (Grant Agreement TSI-064200-2023-1), supported by the Spanish Ministry for Digital Transformation and Civil Service through the UNICO I+D 6G Program, co-funded by the European Union – NextGenerationEU through the Recovery and Resilience Facility (RRF).
+   * `ONEnextgen <http://onenextgen.eu>`__ (Grant Agreement UNICO IPCEI-2023-003), supported by the Spanish Ministry for Digital Transformation and Civil Service through the UNICO IPCEI Program, co-funded by the European Union – NextGenerationEU through the Recovery and Resilience Facility (RRF).

--- a/source/intro_release_notes/release_notes/acknowledgements.rst
+++ b/source/intro_release_notes/release_notes/acknowledgements.rst
@@ -6,8 +6,8 @@ Acknowledgements
 
 The OpenNebula project would like to thank the `community members <https://github.com/OpenNebula/one/graphs/contributors>`__ and `users <http://opennebula.io/featuredusers/>`__ who have contributed to this software release by being active in discussions, answering user questions, or providing patches for bugfixes, features, and documentation.
 
-Part of the new functionality in OpenNebula 6.10 has been funded by the following innovation projects:
+Some of the new functionality in OpenNebula 6.10 has been made possible through funding from the following innovation projects:
 
    * `SovereignEdge.Cognit <http://cognit.sovereignedge.eu>`__ (Grant Agreement 101092711), through the European Union’s Horizon Europe Research and Innovation Programme.
-   * `OneEdge5G <http://oneedge5g.eu>`__ (Grant Agreement TSI-064200-2023-1), supported by the Spanish Ministry for Digital Transformation and Civil Service through the UNICO I+D 6G Program, co-funded by the European Union – NextGenerationEU through the Recovery and Resilience Facility (RRF).
-   * `OneNextGen <http://onenextgen.eu>`__ (Grant Agreement UNICO IPCEI-2023-003), supported by the Spanish Ministry for Digital Transformation and Civil Service through the UNICO IPCEI Program, co-funded by the European Union – NextGenerationEU through the Recovery and Resilience Facility (RRF).
+   * `ONEedge5G <http://oneedge5g.eu>`__ (Grant Agreement TSI-064200-2023-1), supported by Ministerio para la Transformación Digital y de la Función Pública through the UNICO I+D 6G Program, co-funded by the European Union – NextGenerationEU through the Recovery and Resilience Facility (RRF).
+   * `ONEnextGen <http://onenextgen.eu>`__ (Grant Agreement UNICO IPCEI-2023-003), supported by Ministerio para la Transformación Digital y de la Función Pública through the UNICO IPCEI Program, co-funded by the European Union – NextGenerationEU through the Recovery and Resilience Facility (RRF).

--- a/source/intro_release_notes/release_notes/acknowledgements.rst
+++ b/source/intro_release_notes/release_notes/acknowledgements.rst
@@ -8,7 +8,6 @@ The OpenNebula project would like to thank the `community members <https://githu
 
 Some of the new functionality in OpenNebula 6.10 has been made possible through funding from the following innovation projects:
 
-
    * `SovereignEdge.Cognit <http://cognit.sovereignedge.eu>`__ (Grant Agreement 101092711), through the European Union’s Horizon Europe Research and Innovation Programme.
    * `ONEedge5G <http://oneedge5g.eu>`__ (Grant Agreement TSI-064200-2023-1), supported by the Spanish Ministry for Digital Transformation and Civil Service through the UNICO I+D 6G Program, co-funded by the European Union – NextGenerationEU through the Recovery and Resilience Facility (RRF).
    * `ONEnextgen <http://onenextgen.eu>`__ (Grant Agreement UNICO IPCEI-2023-003), supported by the Spanish Ministry for Digital Transformation and Civil Service through the UNICO IPCEI Program, co-funded by the European Union – NextGenerationEU through the Recovery and Resilience Facility (RRF).


### PR DESCRIPTION
### Description

Modified case of project names in ACKs. These changes are already merged into master.
Realized this should be online now, before the next release, for consistency with other materials, so re-issuing.

Applies to one-6.10 and one-6.10-maintenance

- [ ] master
- [ ] one-6.10
- [ ] one-6.10-maintenance

<hr>

- [ ] Check this if this PR should **not** be squashed
