### PR TITLE
M #-: Fix broken reference to docs page

### DIFF
--- a/source/management_and_operations/network_management/overview.rst
+++ b/source/management_and_operations/network_management/overview.rst
@@ -10,7 +10,7 @@ How Should I Read This Chapter
 Before reading this chapter, you should have already installed and configured your cloud. The Chapter is structured as follows:
 
   - The :ref:`Virtual Networks <manage_vnets>` and :ref:`Virtual Networks Templates <vn_templates>` explain how to create networks.
-  - Regular users can self-provision virtual networks for their use. ref:`The details are explained here <self_provision>`.
+  - The :ref:`Self Provision <self_provision>` section details how regular users can self-provision virtual networks for their use.
   - You will also find information on :ref:`Security Groups <security_groups>`, to easily define firewall rules.
   - Additionally you will learn on how to manage :ref:`Virtual Routers <vrouter>` which are an OpenNebula resource that provide routing across Virtual Networks.
 


### PR DESCRIPTION
### Description

Fixed broken reference to the self_provision page.

### Branches to which this PR applies

Would apply to master and 6.10

- [ ] master
- [ ] one-6.10
- [ ] one-6.10-maintenance

<hr>

- [ ] Check this if this PR should **not** be squashed
