### PR TITLE
F #6763 Release notes. Make available "Flush" button on FSunstone to resched all VMs in another hosts

### DIFF
--- a/source/intro_release_notes/release_notes_enterprise/resolved_issues_6103.rst
+++ b/source/intro_release_notes/release_notes_enterprise/resolved_issues_6103.rst
@@ -11,3 +11,4 @@ The following new features have been backported to 6.10.3:
 The following issues has been solved in 6.10.3:
 
 - `Fix an error when downloading images from HTTP-based marketplaces caused by a missing trailing slash in the ENDPOINT attribute <https://github.com/OpenNebula/one/issues/6619>`__.
+- `Fix making available "Flush" button on FSunstone to resched all VMs in another hosts <https://github.com/OpenNebula/one/issues/6763>`__.


### PR DESCRIPTION
### Description

<!--- Please leave a helpful description of the PR here. --->
Release notes for the flush button

### Branches to which this PR applies

<!--- Please check you didn't forget a branch this needs to be cherry picked to. --->

- [ ] master
- [ ] one-6.10
- [x] one-6.10-maintenance

<hr>

- [ ] Check this if this PR should **not** be squashed
