### PR TITLE
M #: Fix CE rhel repo setup code blocks

### DIFF
--- a/source/installation_and_configuration/frontend_installation/opennebula_repository_configuration.rst
+++ b/source/installation_and_configuration/frontend_installation/opennebula_repository_configuration.rst
@@ -168,7 +168,7 @@ To add OpenNebula repository, execute the following as user ``root``:
 **RHEL 8, 9**
 
 .. prompt:: bash # auto
-   :substitutions:
+    :substitutions:
 
     # cat << "EOT" > /etc/yum.repos.d/opennebula.repo
     [opennebula]
@@ -184,7 +184,7 @@ To add OpenNebula repository, execute the following as user ``root``:
 **AlmaLinux 8, 9**
 
 .. prompt:: bash # auto
-   :substitutions:
+    :substitutions:
 
     # cat << "EOT" > /etc/yum.repos.d/opennebula.repo
     [opennebula]

--- a/source/installation_and_configuration/ha/vm_ha.rst
+++ b/source/installation_and_configuration/ha/vm_ha.rst
@@ -67,7 +67,7 @@ This process tries to connect to the host via SSH, synchronize the probes and st
 
 The following is a an example configuration
 
-.. code-block:: language
+.. code-block::
 
     Host *
     ServerAliveInterval 10


### PR DESCRIPTION
### Description

<!--- Please leave a helpful description of the PR here. --->

rhel repo CE code blocks don't work when copying from the doc

![image](https://github.com/user-attachments/assets/3a9990ee-4ae2-44ba-94a0-dcd032622fe0)

```
[root@localhost ~]#  # cat << "EOT" > /etc/yum.repos.d/opennebula.repo
[root@localhost ~]#  [opennebula]
-bash: [opennebula]: command not found
[root@localhost ~]#  name=OpenNebula Community Edition
-bash: Community: command not found
[root@localhost ~]#  baseurl=https://downloads.opennebula.io/repo/7.0/AlmaLinux/$releasever/$basearch
[root@localhost ~]#  enabled=1
[root@localhost ~]#  gpgkey=https://downloads.opennebula.io/repo/repo2.key
[root@localhost ~]#  gpgcheck=1
[root@localhost ~]#  repo_gpgcheck=1
[root@localhost ~]#  EOT
-bash: EOT: command not found
[root@localhost ~]#  # yum makecache
```

EE works

![image](https://github.com/user-attachments/assets/bf36af9d-b112-48ae-8210-1193cca446bd)

```
[root@localhost ~]# cat << "EOT" > /etc/yum.repos.d/opennebula.repo
> [opennebula]
> name=OpenNebula Enterprise Edition
> baseurl=https://<token>@enterprise.opennebula.io/repo/7.0/AlmaLinux/$releasever/$basearch
> enabled=1
> gpgkey=https://downloads.opennebula.io/repo/repo2.key
> gpgcheck=1
> repo_gpgcheck=1
> EOT
[root@localhost ~]# yum makecache
AlmaLinux 8 - BaseOS                                                                                                                               12 kB/s | 3.8 kB     00:00
AlmaLinux 8 - AppStream                                                                                                                            15 kB/s | 4.3 kB     00:00
AlmaLinux 8 - Extras                                                                                                                               11 kB/s | 3.3 kB     00:00
Extra Packages for Enterprise Linux 8 - x86_64                                                                                                     50 kB/s |  37 kB     00:00
OpenNebula Enterprise Edition                                                                                                                     334  B/s | 381  B     00:01
Errors during downloading metadata for repository 'opennebula':
  - Status code: 401 for https://<token>@enterprise.opennebula.io/repo/7.0/AlmaLinux/8/x86_64/repodata/repomd.xml (IP: 139.162.168.171)
Error: Failed to download metadata for repo 'opennebula': Cannot download repomd.xml: Cannot download repodata/repomd.xml: All mirrors were tried
```

Also fix a warning with VM HA code block

### Branches to which this PR applies

<!--- Please check you didn't forget a branch this needs to be cherry picked to. --->

- [ ] master
- [ ] one-6.10
- [ ] one-6.10-maintenance

<hr>

- [ ] Check this if this PR should **not** be squashed
