### PR TITLE
M #-: Add #6463 to known issues (libvirtd restart each 10 minutes)

### DIFF
--- a/source/intro_release_notes/release_notes/known_issues.rst
+++ b/source/intro_release_notes/release_notes/known_issues.rst
@@ -8,6 +8,11 @@ A complete list of `known issues for OpenNebula is maintained here <https://gith
 
 This page will be updated with relevant information about bugs affecting OpenNebula, as well as possible workarounds until a patch is officially published.
 
+Drivers - Virtualization
+================================================================================
+
+- `libvirtd restarts in cycles each 10 minutes with error message in system logs <https://github.com/OpenNebula/one/issues/6463>`_, due to the way libvirtd gets activated per interaction by systemd in 120-second slices. As the default interval for the OpenNebula monitor probe is 600 seconds (10 minutes), each time a probe reactivates libvirtd, it sends those messages to syslog.
+
 Drivers - Network
 ================================================================================
 


### PR DESCRIPTION
### Description

Add https://github.com/OpenNebula/one/issues/6463 (libvirtd restart each 10 minutes) to known issues since one-6.8, which probably made it appear after virsh started being called as oneadmin instead of root from the monitor.

### Branches to which this PR applies

<!--- Please check you didn't forget a branch this needs to be cherry picked to. --->

- [X] master
- [X] one-6.10
- [X] one-6.8

<hr>

- [ ] Check this if this PR should **not** be squashed
