### PR TITLE
B OpenNebula/One#6781: add issue 6781 in known issues file

### DIFF
--- a/source/intro_release_notes/release_notes/known_issues.rst
+++ b/source/intro_release_notes/release_notes/known_issues.rst
@@ -32,6 +32,9 @@ Sunstone
 
 - The `Update VM Configuration` dialog contains a bug which will result in a blank screen if one tries to update the configuration of a virtual machine with less than 2 total disks attached. The quickest workaround for this is to attach another minimal disk to the VM.
 
+- When deleting an element in the datatable. such as running the terminate in a VM, we recommend refreshing the window. as there is an error in the client code discussed in the following `issue <https://github.com/OpenNebula/one/issues/6781>`__.
+
+
 Install Linux Graphical Desktop on KVM Virtual Machines
 ================================================================================
 


### PR DESCRIPTION
### Description

This PR adds in the known issue the error of the datatable rows deselection. you can't move the code from 7.0 to 6.10. because there is an error in the react dependencies. and you have to change all the graphics as they are in 7.0.

### Branches to which this PR applies

<!--- Please check you didn't forget a branch this needs to be cherry picked to. --->

- [ ] one-6.10-maintenance

<hr>

- [ ] Check this if this PR should **not** be squashed
