### PR TITLE
F#821: Added key -t, --timezone to set specific timezone for oneacct

### DIFF
--- a/source/intro_release_notes/release_notes_enterprise/resolved_issues_6104.rst
+++ b/source/intro_release_notes/release_notes_enterprise/resolved_issues_6104.rst
@@ -1,0 +1,1 @@
+- `Add support of using defined timezone by oneacct utility with flag -t/--timezone  <https://github.com/OpenNebula/one/issues/821>`__.


### PR DESCRIPTION

### Description

- `Add support of using defined timezone by oneacct utility with flag -t/--timezone  <https://github.com/OpenNebula/one/issues/821>`__.


### Branches to which this PR applies

<!--- Please check you didn't forget a branch this needs to be cherry picked to. --->

- [ ] one-6.10-maintenance

<hr>

- [ ] Check this if this PR should **not** be squashed
