### PR TITLE
F OpenNebula/one#821: Added key -t, --timezone to set specific timezone by oneacct

### DIFF
--- a/source/intro_release_notes/release_notes_enterprise/resolved_issues_6104.rst
+++ b/source/intro_release_notes/release_notes_enterprise/resolved_issues_6104.rst
@@ -7,6 +7,7 @@ A complete list of solved issues for 6.10.4 can be found in the `project develop
 
 The following new features have been backported to 6.10.4:
 
+- `Add support of using defined timezone by oneacct utility with flag -t/--timezone  <https://github.com/OpenNebula/one/issues/821>`__.
 
 The following issues has been solved in 6.10.4:
 


### PR DESCRIPTION
### Description

Add support of using defined timezone by oneacct utility with flag -t/--timezone  <https://github.com/OpenNebula/one/issues/821>__.

Branches to which this PR applies

### Branches to which this PR applies

<!--- Please check you didn't forget a branch this needs to be cherry picked to. --->

- [x] one-6.10-maintenance

<hr>

- [ ] Check this if this PR should **not** be squashed
