### PR TITLE
B OpenNebula/one#6997: VM migration not executed on vCenter when src host ID is 0

### DIFF
--- a/source/intro_release_notes/release_notes_enterprise/resolved_issues_6104.rst
+++ b/source/intro_release_notes/release_notes_enterprise/resolved_issues_6104.rst
@@ -14,6 +14,7 @@ The following issues has been solved in 6.10.4:
 - `Fix a bug when Restic passwords include quotes <https://github.com/OpenNebula/one/issues/6666/>`__.
 - `Fix onevrouter instantiate command prompts for user input unnecessarily <https://github.com/OpenNebula/one/issues/6948/>`__.
 - `Fix user-input option for CLI to support values containing commas and equal signs <https://github.com/OpenNebula/one/issues/6975/>`__.
+- `Fix VM migration not executed on vCenter when src host ID is 0 <https://github.com/OpenNebula/one/issues/6997/>`__.
 
 The following issues have been solved in the Sunstone Web UI:
 


### PR DESCRIPTION
### Description

Add Fix VM migration not executed on vCenter when src host ID is 0 https://github.com/OpenNebula/one/issues/6997/

### Branches to which this PR applies

<!--- Please check you didn't forget a branch this needs to be cherry picked to. --->

- [x] one-6.10-maintenance

<hr>

- [ ] Check this if this PR should **not** be squashed
