### PR TITLE
M #-: Remove ref to sched daemon in Rank Scheduler page

### DIFF
--- a/source/management_and_operations/capacity_planning/scheduler/rank_scheduler.rst
+++ b/source/management_and_operations/capacity_planning/scheduler/rank_scheduler.rst
@@ -4,7 +4,7 @@
 Rank Scheduler
 ================================================================================
 
-The OpenNebula Rank Scheduler is responsible for **allocating pending Virtual Machines to available hypervisor Nodes**. It's a dedicated daemon installed alongside the OpenNebula Daemon (``oned``), but can be deployed independently on a different machine. The Scheduler is distributed as part of the operating system package ``opennebula`` with the system service ``opennebula-scheduler``.
+The OpenNebula Rank Scheduler is responsible for **allocating pending Virtual Machines to available hypervisor Nodes**. As part of the OpenNebula Scheduler framework, it is started automatically with the OpenNebula daemon. It’s the default scheduler option for VM placement.
 
 .. _scheduler_rank_matchmaking:
 


### PR DESCRIPTION
### Description

Remove reference to dedicated daemon in introductory paragraph to the Rank Scheduler .

### Branches to which this PR applies

<!--- Please check you didn't forget a branch this needs to be cherry picked to. --->

- [ ] master
- [ ] one-6.10
- [ ] one-6.10-maintenance

<hr>

- [ ] Check this if this PR should **not** be squashed
