### PR TITLE
F #-: clarify PHP 7.4 is required

### DIFF
--- a/source/installation_and_configuration/whmcs_tenants/configure.rst
+++ b/source/installation_and_configuration/whmcs_tenants/configure.rst
@@ -4,12 +4,13 @@
 WHMCS Tenants Module Install/Update
 ===================================
 
+.. warning:: You must use PHP 7.4, currently PHP 8.x will cause an error when creating the user
+
 The install and update process are essentially identical. The Module files can be found in */usr/share/one/whmcs* after you have installed the *opennebula-whmcs-tenants* package via your package manager. You will just need to merge the *modules* directory to the main WHMCS directory on the server hosting WHMCS. When updating the module just copy the files on top of the existing files and overwrite them. An example command for copying the files:
 
 .. code-block:: bash
 
     cp -rf /usr/share/one/whmcs/modules /path/to/web/root/whmcs/.
-
 
 
 .. note:: Make sure you download the updated package from the EE repository before doing either an install or an update.


### PR DESCRIPTION
### Description

add a warning to let WHMCS users know that PHP 8.x does not work, and requires 7.4 instead.

### Branches to which this PR applies

<!--- Please check you didn't forget a branch this needs to be cherry picked to. --->

- [ ] master
- [ ] one-6.10
