### PR TITLE
 OpenNebula/one#7031 re-arrange time orders on vm creation

### DIFF
--- a/source/intro_release_notes/release_notes_enterprise/resolved_issues_6105.rst
+++ b/source/intro_release_notes/release_notes_enterprise/resolved_issues_6105.rst
@@ -24,6 +24,7 @@ The following issues has been solved in 6.10.5:
 - `Fix Sunstone VM search leads to blank page <https://github.com/OpenNebula/one/issues/7060>`__.
 - `Fix Don't let add the ssh key more than one time <https://github.com/OpenNebula/one/issues/7140>`__.
 - `Fix VIRTIO_QUEUES not applying to hot plugged virtio NICs <https://github.com/OpenNebula/one/issues/7195>`__.
+- `Fix re-arrange time orders when adding a scheduled action in Creating VMs. <https://github.com/OpenNebula/one/issues/7031>`
 
 Changes in Configuration Files
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
### Description

<!--- Please leave a helpful description of the PR here. --->
Re-arranged the time orders when adding a scheduled action in Creating VMs.

### Branches to which this PR applies

<!--- Please check you didn't forget a branch this needs to be cherry picked to. --->

- [x] one-6.10-maintenance

<hr>

- [ ] Check this if this PR should **not** be squashed
