### PR TITLE
M #-: fix the Nginx example configuration in sunstone_auth.rst

### DIFF
--- a/source/installation_and_configuration/authentication/sunstone_auth.rst
+++ b/source/installation_and_configuration/authentication/sunstone_auth.rst
@@ -131,7 +131,7 @@ Nginx
     ssl_verify_client optional;  
     location / {
         ...
-        proxy_set_header X-Client-Dn $client_dn;
+        proxy_set_header X-Client-Dn $ssl_client_s_dn;
     }
  
 


### PR DESCRIPTION
### Description

The SSL module in Nginx does not have a `$client_dn` variable, but it does have `$ssl_client_s_dn` (a similar one to Apache's example) that returns the “subject DN” string of the client certificate for an established SSL connection according to RFC 2253 (1.11.6)

Source: https://nginx.org/en/docs/http/ngx_http_ssl_module.html#var_ssl_client_s_dn
### Branches to which this PR applies

- [x] master
- [x] one-7.0
- [ ] one-X.X-maintenance

<hr>

- [ ] Check this if this PR should **not** be squashed
