### PR TITLE
F OpenNebula/one#7425: Update resolved issues for issue 7425

### DIFF
--- a/source/intro_release_notes/release_notes_enterprise/resolved_issues_6106.rst
+++ b/source/intro_release_notes/release_notes_enterprise/resolved_issues_6106.rst
@@ -13,6 +13,7 @@ The following issues has been solved in 6.10.6:
 
 - `Fix [FSunstone] CPU_MODEL removed on VM configuration update <https://github.com/OpenNebula/one/issues/6860>`__.
 - `Fix [FSunstone] Refresh view when change group or zone <https://github.com/OpenNebula/one/issues/7554>`__.
+- `Fix persistent image creation when saving a VM as a template in Sunstone <https://github.com/OpenNebula/one/issues/7425>`__.
 
 
 Changes in Configuration Files


### PR DESCRIPTION
### Description

## Summary

Documents OpenNebula issue #7425 as resolved in version 6.10.6, covering the Sunstone fix related to persistent image creation when saving a VM as a template.

## Modified files

- `source/intro_release_notes/release_notes_enterprise/resolved_issues_6106.rst`
  Added issue #7425 to the list of issues solved in OpenNebula 6.10.6. The final newline was also removed.

### Branches to which this PR applies

<!--- Please check you didn't forget a branch this needs to be cherry picked to. --->

- [ ] one-6.10-maintenance

<hr>

- [ ] Check this if this PR should **not** be squashed
