### PR TITLE
F OpenNebula/one#7426: Add resolved issues for issue 7426

### DIFF
--- a/source/intro_release_notes/release_notes_enterprise/resolved_issues_6106.rst
+++ b/source/intro_release_notes/release_notes_enterprise/resolved_issues_6106.rst
@@ -14,6 +14,7 @@ The following issues has been solved in 6.10.6:
 - `Fix [FSunstone] CPU_MODEL removed on VM configuration update <https://github.com/OpenNebula/one/issues/6860>`__.
 - `Fix [FSunstone] Refresh view when change group or zone <https://github.com/OpenNebula/one/issues/7554>`__.
 - `Fix persistent image creation when saving a VM as a template in Sunstone <https://github.com/OpenNebula/one/issues/7425>`__.
+- `Fix VM template instantiation to allow precise memory values to be entered directly when memory modification is configured as a range <https://github.com/OpenNebula/one/issues/7426>`__.
 
 
 Changes in Configuration Files


### PR DESCRIPTION
### Description

## Summary

Document issue #7426 as resolved in OpenNebula 6.10.6, covering direct entry of precise memory values when range-based memory modification is enabled.

## Modified files

- `source/intro_release_notes/release_notes_enterprise/resolved_issues_6106.rst`
  - Added the resolved issue entry for direct memory range input during VM template instantiation.

### Branches to which this PR applies

<!--- Please check you didn't forget a branch this needs to be cherry picked to. --->

- [ ] one-6.10-maintenance

<hr>

- [ ] Check this if this PR should **not** be squashed
